### PR TITLE
Add bitwise operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,6 @@ Arithmetic operators:
 Logical operators:
 - `and`, `&&`: Logical and
 - `or`, `||`: Logical or
-- `xor`, `^^`: Logical xor
 - `not`, `!`: Logical not
 
 Bitwise operators:

--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ Arithmetic operators:
 Logical operators:
 - `and`, `&&`: Logical and
 - `or`, `||`: Logical or
+- `xor`: Logical xor
 - `not`, `!`: Logical not
 
 Bitwise operators:

--- a/README.md
+++ b/README.md
@@ -428,15 +428,14 @@ Logical operators:
 - `xor`, `^^`: Logical xor
 - `not`, `!`: Logical not
 
-> [!WARNING]
-> Bitwise operators are implemented yet
-Bitwise operators are prefixed with b:
-- `b|`: Bitwise or
-- `b&`: Bitwise and
-- `b^`: Bitwise xor
-- `b<<`: Bitwise left shift
-- `b>>`: Bitwise right shift
-- `b~`: Bitwise not
+Bitwise operators:
+- `|`: Bitwise or
+- `&`: Bitwise and
+- `~`: Bitwise xor
+- `<<`: Bitwise left shift
+- `>>`: Bitwise right shift
+
+Like in Lua, `^` is exponentiation and `~` is bitwise xor.
 
 Comparison operators:
 - `==`: Equality

--- a/galvan-ast/src/item/infix_operator.rs
+++ b/galvan-ast/src/item/infix_operator.rs
@@ -78,6 +78,7 @@ impl InfixOperation<MemberOperator> {
 pub enum LogicalOperator {
     Or,
     And,
+    Xor,
 }
 
 impl InfixOperator for LogicalOperator {
@@ -85,6 +86,7 @@ impl InfixOperator for LogicalOperator {
         match self {
             LogicalOperator::Or => "||",
             LogicalOperator::And => "&&",
+            LogicalOperator::Xor => "xor",
         }
     }
 }

--- a/galvan-ast/src/item/infix_operator.rs
+++ b/galvan-ast/src/item/infix_operator.rs
@@ -13,6 +13,7 @@ pub trait InfixOperator {
 pub enum InfixExpression {
     Logical(InfixOperation<LogicalOperator>),
     Arithmetic(InfixOperation<ArithmeticOperator>),
+    Bitwise(InfixOperation<BitwiseOperator>),
     Collection(InfixOperation<CollectionOperator>),
     Range(InfixOperation<RangeOperator>),
     Comparison(InfixOperation<ComparisonOperator>),
@@ -109,6 +110,27 @@ impl InfixOperator for ArithmeticOperator {
             ArithmeticOperator::Div => "/",
             ArithmeticOperator::Rem => "%",
             ArithmeticOperator::Exp => "^",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BitwiseOperator {
+    Or,
+    And,
+    Xor,
+    ShiftLeft,
+    ShiftRight,
+}
+
+impl InfixOperator for BitwiseOperator {
+    fn symbol(&self) -> &str {
+        match self {
+            BitwiseOperator::Or => "|",
+            BitwiseOperator::And => "&",
+            BitwiseOperator::Xor => "~",
+            BitwiseOperator::ShiftLeft => "<<",
+            BitwiseOperator::ShiftRight => ">>",
         }
     }
 }

--- a/galvan-ast/src/item/infix_operator.rs
+++ b/galvan-ast/src/item/infix_operator.rs
@@ -78,7 +78,6 @@ impl InfixOperation<MemberOperator> {
 pub enum LogicalOperator {
     Or,
     And,
-    Xor,
 }
 
 impl InfixOperator for LogicalOperator {
@@ -86,7 +85,6 @@ impl InfixOperator for LogicalOperator {
         match self {
             LogicalOperator::Or => "||",
             LogicalOperator::And => "&&",
-            LogicalOperator::Xor => "^",
         }
     }
 }

--- a/galvan-hir/src/hir.rs
+++ b/galvan-hir/src/hir.rs
@@ -16,9 +16,9 @@
 //! therefore *is* the ownership of the generated Rust expression.
 
 use galvan_ast::{
-    ArithmeticOperator, CmdSignature, ComparisonOperator, DeclModifier, FnSignature, Ident,
-    LogicalOperator, Ownership, RangeOperator, Span, StringLiteral, ToplevelItem, TypeDecl,
-    TypeElement, TypeIdent,
+    ArithmeticOperator, BitwiseOperator, CmdSignature, ComparisonOperator, DeclModifier,
+    FnSignature, Ident, LogicalOperator, Ownership, RangeOperator, Span, StringLiteral,
+    ToplevelItem, TypeDecl, TypeElement, TypeIdent,
 };
 use galvan_files::Source;
 
@@ -259,6 +259,7 @@ pub enum HirExpressionKind {
     Closure(Box<HirClosure>),
     Logical(Box<HirBinary<LogicalOperator>>),
     Arithmetic(Box<HirBinary<ArithmeticOperator>>),
+    Bitwise(Box<HirBinary<BitwiseOperator>>),
     Comparison(Box<HirBinary<ComparisonOperator>>),
     CollectionOp(Box<HirBinary<CollectionOperator>>),
     Range(Box<HirBinary<RangeOperator>>),

--- a/galvan-hir/src/typecheck/expr.rs
+++ b/galvan-hir/src/typecheck/expr.rs
@@ -1193,6 +1193,27 @@ impl Checker<'_> {
                     span,
                 )
             }
+            InfixExpression::Bitwise(operation) => {
+                let lhs = self.lower_expression(&operation.lhs, &Expected::free());
+                let rhs = self.lower_expression(&operation.rhs, &Expected::free());
+
+                let ty = if lhs.ty.is_infer() || lhs.ty.is_number() {
+                    rhs.ty.clone()
+                } else {
+                    lhs.ty.clone()
+                };
+
+                HirExpression::new(
+                    HirExpressionKind::Bitwise(Box::new(HirBinary {
+                        lhs,
+                        operator: operation.operator.clone(),
+                        rhs,
+                    })),
+                    ty,
+                    Ownership::UniqueOwned,
+                    span,
+                )
+            }
             InfixExpression::Comparison(operation) => {
                 let lhs = self.lower_expression(&operation.lhs, &Expected::free());
                 let rhs = self.lower_expression(&operation.rhs, &Expected::free());

--- a/galvan-into-ast/src/items/expression/infix.rs
+++ b/galvan-into-ast/src/items/expression/infix.rs
@@ -119,7 +119,6 @@ impl ReadCursor for LogicalOperator {
         let op = match cursor.kind()? {
             "and" => Self::And,
             "or" => Self::Or,
-            "xor" => Self::Xor,
             unknown => unreachable!("Unknown logical operator: {unknown}"),
         };
 

--- a/galvan-into-ast/src/items/expression/infix.rs
+++ b/galvan-into-ast/src/items/expression/infix.rs
@@ -1,6 +1,6 @@
 use galvan_ast::{
-    ArithmeticOperator, CollectionOperator, ComparisonOperator, CustomInfix, EnumAccess,
-    Expression, Group, InfixExpression, InfixOperation, InfixOperator, LogicalOperator,
+    ArithmeticOperator, BitwiseOperator, CollectionOperator, ComparisonOperator, CustomInfix,
+    EnumAccess, Expression, Group, InfixExpression, InfixOperation, InfixOperator, LogicalOperator,
     MemberOperator, RangeOperator, Span, TypeIdent,
 };
 use galvan_parse::TreeCursor;
@@ -58,6 +58,9 @@ impl ReadCursor for InfixExpression {
                     cursor, source,
                 )?)
             }
+            "bitwise_expression" => InfixExpression::Bitwise(
+                InfixOperation::<BitwiseOperator>::read_cursor(cursor, source)?,
+            ),
             "collection_expression" => {
                 InfixExpression::Collection(InfixOperation::<CollectionOperator>::read_cursor(
                     cursor, source,
@@ -134,6 +137,21 @@ impl ReadCursor for ArithmeticOperator {
             "remainder" => Self::Rem,
             "power" => Self::Exp,
             unknown => unreachable!("Unknown arithmetic operator: {unknown}"),
+        };
+
+        Ok(op)
+    }
+}
+
+impl ReadCursor for BitwiseOperator {
+    fn read_cursor(cursor: &mut TreeCursor<'_>, _source: &str) -> Result<Self, AstError> {
+        let op = match cursor.kind()? {
+            "pipe" => Self::Or,
+            "bitwise_and" => Self::And,
+            "bitwise_xor" => Self::Xor,
+            "shift_left" => Self::ShiftLeft,
+            "shift_right" => Self::ShiftRight,
+            unknown => unreachable!("Unknown bitwise operator: {unknown}"),
         };
 
         Ok(op)

--- a/galvan-into-ast/src/items/expression/infix.rs
+++ b/galvan-into-ast/src/items/expression/infix.rs
@@ -119,6 +119,7 @@ impl ReadCursor for LogicalOperator {
         let op = match cursor.kind()? {
             "and" => Self::And,
             "or" => Self::Or,
+            "xor" => Self::Xor,
             unknown => unreachable!("Unknown logical operator: {unknown}"),
         };
 

--- a/galvan-test/src/bitwise.galvan
+++ b/galvan-test/src/bitwise.galvan
@@ -1,0 +1,25 @@
+test "Bitwise or" {
+    assert 5 | 3 == 7
+}
+
+test "Bitwise and" {
+    assert 6 & 3 == 2
+}
+
+test "Bitwise xor" {
+    assert 5 ~ 3 == 6
+}
+
+test "Bitwise left shift" {
+    assert 1 << 4 == 16
+}
+
+test "Bitwise right shift" {
+    assert 16 >> 3 == 2
+}
+
+test "Bitwise operator precedence" {
+    assert 1 | 2 & 3 == 3
+    assert 1 ~ 3 & 1 == 0
+    assert 1 << 2 + 1 == 8
+}

--- a/galvan-test/src/logical.galvan
+++ b/galvan-test/src/logical.galvan
@@ -21,3 +21,10 @@ test "Logical OR" {
 
     assert a or b == false
 }
+
+test "Logical XOR" {
+    assert(true xor false)
+    assert(false xor true)
+    assert(true xor true == false)
+    assert(false xor false == false)
+}

--- a/galvan-transpiler/src/codegen/expression.rs
+++ b/galvan-transpiler/src/codegen/expression.rs
@@ -445,7 +445,6 @@ impl Transpile for HirBinary<LogicalOperator> {
         match self.operator {
             LogicalOperator::And => transpile!(ctx, errors, "{} && {}", self.lhs, self.rhs),
             LogicalOperator::Or => transpile!(ctx, errors, "{} || {}", self.lhs, self.rhs),
-            LogicalOperator::Xor => transpile!(ctx, errors, "{} ^ {}", self.lhs, self.rhs),
         }
     }
 }

--- a/galvan-transpiler/src/codegen/expression.rs
+++ b/galvan-transpiler/src/codegen/expression.rs
@@ -445,6 +445,7 @@ impl Transpile for HirBinary<LogicalOperator> {
         match self.operator {
             LogicalOperator::And => transpile!(ctx, errors, "{} && {}", self.lhs, self.rhs),
             LogicalOperator::Or => transpile!(ctx, errors, "{} || {}", self.lhs, self.rhs),
+            LogicalOperator::Xor => transpile!(ctx, errors, "{} ^ {}", self.lhs, self.rhs),
         }
     }
 }

--- a/galvan-transpiler/src/codegen/expression.rs
+++ b/galvan-transpiler/src/codegen/expression.rs
@@ -1,5 +1,6 @@
 use galvan_ast::{
-    ArithmeticOperator, ComparisonOperator, LogicalOperator, RangeOperator, TypeElement,
+    ArithmeticOperator, BitwiseOperator, ComparisonOperator, LogicalOperator, RangeOperator,
+    TypeElement,
 };
 use galvan_hir::hir::*;
 use itertools::Itertools;
@@ -34,6 +35,7 @@ impl Transpile for HirExpressionKind {
             HirExpressionKind::Closure(closure) => closure.transpile(ctx, errors),
             HirExpressionKind::Logical(operation) => operation.transpile(ctx, errors),
             HirExpressionKind::Arithmetic(operation) => operation.transpile(ctx, errors),
+            HirExpressionKind::Bitwise(operation) => operation.transpile(ctx, errors),
             HirExpressionKind::Comparison(operation) => operation.transpile(ctx, errors),
             HirExpressionKind::CollectionOp(operation) => operation.transpile(ctx, errors),
             HirExpressionKind::Range(operation) => operation.transpile(ctx, errors),
@@ -457,6 +459,18 @@ impl Transpile for HirBinary<ArithmeticOperator> {
             ArithmeticOperator::Div => transpile!(ctx, errors, "{} / {}", self.lhs, self.rhs),
             ArithmeticOperator::Rem => transpile!(ctx, errors, "{} % {}", self.lhs, self.rhs),
             ArithmeticOperator::Exp => transpile!(ctx, errors, "{}.pow({})", self.lhs, self.rhs),
+        }
+    }
+}
+
+impl Transpile for HirBinary<BitwiseOperator> {
+    fn transpile(&self, ctx: &Context, errors: &mut ErrorCollector) -> String {
+        match self.operator {
+            BitwiseOperator::Or => transpile!(ctx, errors, "{} | {}", self.lhs, self.rhs),
+            BitwiseOperator::And => transpile!(ctx, errors, "{} & {}", self.lhs, self.rhs),
+            BitwiseOperator::Xor => transpile!(ctx, errors, "{} ^ {}", self.lhs, self.rhs),
+            BitwiseOperator::ShiftLeft => transpile!(ctx, errors, "{} << {}", self.lhs, self.rhs),
+            BitwiseOperator::ShiftRight => transpile!(ctx, errors, "{} >> {}", self.lhs, self.rhs),
         }
     }
 }

--- a/galvan-transpiler/src/codegen/mod.rs
+++ b/galvan-transpiler/src/codegen/mod.rs
@@ -71,6 +71,6 @@ fn needs_parens(kind: &HirExpressionKind) -> bool {
         | SafeAccess(_) | ConstructorCall(_) | EnumAccess(_) | EnumConstructor(_)
         | Collection(_) | Index(_) | Group(_) | Yeet(_) | Print(_) | Assert(_) | Error(_) => false,
         If(_) | ElseUnwrap(_) | Try(_) | For(_) | Closure(_) | Logical(_) | Arithmetic(_)
-        | Comparison(_) | CollectionOp(_) | Range(_) => true,
+        | Bitwise(_) | Comparison(_) | CollectionOp(_) | Range(_) => true,
     }
 }

--- a/todo.md
+++ b/todo.md
@@ -24,6 +24,7 @@ stored in them.
   - Remove operator `--` for collections (codegen/expression.rs renders a
     placeholder comment)
   - Custom infix operators (typecheck/expr.rs `lower_infix`)
+  - Add unary expression support for logical and bitwise not
 
 - **Parameter modifiers in calls** (galvan-hir/src/typecheck/expr.rs `lower_call_args`)
   - Arguments for `let`-modified parameters are not implemented
@@ -88,5 +89,5 @@ stored in them.
   formatting (galvan-transpiler/src/lib.rs)
 
 ---
-*Last updated: 2026-06-17*
+*Last updated: 2026-06-19*
 *This file should be updated regularly as TODOs are completed or new ones are discovered*


### PR DESCRIPTION
Bitwise operators now use Lua syntax (~ for xor) instead of a prefix to avoid collisions with exponentiation (^)