### PR TITLE
Improve string interpolation

### DIFF
--- a/example-projects/cli-app/src/main.galvan
+++ b/example-projects/cli-app/src/main.galvan
@@ -14,8 +14,8 @@ cmd greet(
     s surname: String?
 ) {
     try surname |surname| {
-        print "Hello {name} {surname}!"
+        print "Hello \(name) \(surname)!"
     } else {
-        print "Hello {name}!"
+        print "Hello \(name)!"
     }
 }

--- a/galvan-ast/src/item/literal.rs
+++ b/galvan-ast/src/item/literal.rs
@@ -12,7 +12,7 @@ pub type Literal = StringLiteral + NumberLiteral + BooleanLiteral + NoneLiteral 
 #[derive(Clone, Debug, PartialEq, Eq, From)]
 pub struct StringLiteral {
     pub value: String,
-    pub interpolations: Vec<Expression>, // Expressions found in {expr} within the string
+    pub interpolations: Vec<Expression>,
     pub span: Span,
 }
 

--- a/galvan-examples/function_call.galvan
+++ b/galvan-examples/function_call.galvan
@@ -1,5 +1,5 @@
 fn greet(name: String) {
-    let greetings = "Hello, {name}!"
+    let greetings = "Hello, \(name)!"
     print(greetings)
 }
 

--- a/galvan-hir/src/hir.rs
+++ b/galvan-hir/src/hir.rs
@@ -473,7 +473,8 @@ pub enum HirLiteral {
 
 #[derive(Clone, Debug)]
 pub struct HirStringLiteral {
-    /// The raw string literal including quotes and `{}` placeholders
+    /// The Rust format string literal including quotes and `{}` placeholders.
+    /// Literal braces are escaped as `{{` and `}}`.
     pub value: String,
     pub interpolations: Vec<HirExpression>,
 }

--- a/galvan-hir/src/typecheck/expr.rs
+++ b/galvan-hir/src/typecheck/expr.rs
@@ -171,7 +171,7 @@ impl Checker<'_> {
                 let interpolations = string
                     .interpolations
                     .iter()
-                    .map(|interpolation| self.lower_interpolation(interpolation))
+                    .map(|interpolation| self.lower_expression(interpolation, &Expected::free()))
                     .collect();
                 (
                     HirLiteral::String(HirStringLiteral {
@@ -189,28 +189,6 @@ impl Checker<'_> {
             Ownership::UniqueOwned,
             span,
         )
-    }
-
-    /// Lowers a string interpolation argument. When parsing the interpolated
-    /// source failed, the AST falls back to an identifier containing the raw
-    /// expression source (e.g. `dog.name`); such identifiers are rendered
-    /// verbatim instead of being resolved as variables.
-    fn lower_interpolation(&mut self, interpolation: &Expression) -> HirExpression {
-        if let ExpressionKind::Ident(ident) = &interpolation.kind {
-            let is_fallback = ident
-                .as_str()
-                .contains(|c: char| !c.is_alphanumeric() && c != '_');
-            if is_fallback {
-                return HirExpression::new(
-                    HirExpressionKind::Variable(ident.clone()),
-                    TypeElement::infer(),
-                    Ownership::Borrowed,
-                    interpolation.span,
-                );
-            }
-        }
-
-        self.lower_expression(interpolation, &Expected::free())
     }
 
     // ------------------------------------------------------------------

--- a/galvan-into-ast/src/items/literal.rs
+++ b/galvan-into-ast/src/items/literal.rs
@@ -1,84 +1,50 @@
 use galvan_ast::{
-    BooleanLiteral, CharLiteral, Expression, ExpressionKind, Ident, Literal, NoneLiteral,
-    NumberLiteral, Span, StringLiteral,
+    BooleanLiteral, CharLiteral, Expression, Literal, NoneLiteral, NumberLiteral, Span,
+    StringLiteral,
 };
 use galvan_parse::TreeCursor;
 
 use crate::{cursor_expect, result::CursorUtil, AstError, ReadCursor, SpanExt};
 
-// Function to parse an arbitrary expression from string content
-fn parse_interpolation_expression(expr_content: &str, span: &Span) -> Result<Expression, AstError> {
-    // Create a minimal wrapper to parse the expression
-    // We'll wrap it in a simple statement that we can parse
-    let wrapper_source = format!("fn __temp() {{ let __x = {}; }}", expr_content);
-    let source = galvan_files::Source::Str(wrapper_source.clone().into());
+fn push_escaped_format_text(output: &mut String, text: &str) {
+    let mut chars = text.chars().peekable();
 
-    // Parse the wrapper source
-    match galvan_parse::parse_source(&source) {
-        Ok(parsed_tree) => {
-            // Create a cursor from the parsed tree
-            let mut cursor = parsed_tree.root_node().walk();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => {
+                output.push(ch);
+                let Some(escaped) = chars.next() else {
+                    continue;
+                };
+                output.push(escaped);
 
-            // Navigate to find the expression we want
-            // Structure: source -> function -> body -> statement -> declaration -> expression
-            if cursor.child() && // Enter source
-               cursor.child() && // Enter function
-               cursor_goto_named(&mut cursor, "body") &&
-               cursor.child() && // Enter body
-               cursor.child() && // Enter statement
-               cursor_goto_named(&mut cursor, "declaration") &&
-               cursor.child() && // Enter declaration
-               cursor_goto_named(&mut cursor, "expression")
-            {
-                // Found the expression, parse it
-                match Expression::read_cursor(&mut cursor, &wrapper_source) {
-                    Ok(expr) => Ok(expr),
-                    Err(_) => {
-                        // Fallback to creating identifier
-                        create_fallback_expression(expr_content, span)
+                if escaped == 'u' && chars.peek() == Some(&'{') {
+                    for unicode_char in chars.by_ref() {
+                        output.push(unicode_char);
+                        if unicode_char == '}' {
+                            break;
+                        }
                     }
                 }
-            } else {
-                // Navigation failed, create fallback
-                create_fallback_expression(expr_content, span)
             }
-        }
-        Err(_) => {
-            // Parsing failed, create fallback
-            create_fallback_expression(expr_content, span)
+            '{' => output.push_str("{{"),
+            '}' => output.push_str("}}"),
+            _ => output.push(ch),
         }
     }
 }
 
-// Helper function to navigate to a named child node
-fn cursor_goto_named(cursor: &mut TreeCursor<'_>, name: &str) -> bool {
+fn read_interpolation(cursor: &mut TreeCursor<'_>, source: &str) -> Result<Expression, AstError> {
+    cursor_expect!(cursor, "string_interpolation");
+    cursor.child();
+
     loop {
-        if cursor.kind().unwrap_or("") == name {
-            return true;
+        if cursor.kind()? == "expression" {
+            return Expression::read_cursor(cursor, source);
         }
-        if !cursor.goto_next_sibling() {
-            return false;
+        if !cursor.next() {
+            return Err(AstError::ConversionError);
         }
-    }
-}
-
-// Helper function to create fallback expressions
-fn create_fallback_expression(expr_content: &str, span: &Span) -> Result<Expression, AstError> {
-    if expr_content
-        .chars()
-        .all(|c| c.is_alphanumeric() || c == '_')
-    {
-        // Simple identifier
-        Ok(Expression {
-            kind: ExpressionKind::Ident(Ident::new(expr_content)),
-            span: span.clone(),
-        })
-    } else {
-        // Treat as identifier anyway - let the transpiler handle complex syntax
-        Ok(Expression {
-            kind: ExpressionKind::Ident(Ident::new(expr_content)),
-            span: span.clone(),
-        })
     }
 }
 
@@ -134,65 +100,35 @@ impl ReadCursor for StringLiteral {
     fn read_cursor(cursor: &mut TreeCursor<'_>, source: &str) -> Result<Self, AstError> {
         let node = cursor_expect!(cursor, "string_literal");
         let span = Span::from_node(node);
-        let full_text = source[node.start_byte()..node.end_byte()].to_owned();
-
+        let mut value = String::new();
         let mut interpolations = Vec::new();
+        let mut last_byte = node.start_byte();
+        let mut child_cursor = node.walk();
 
-        // Simple approach: manually parse the string and replace interpolations with placeholders
-        if full_text.contains('{') && full_text.contains('}') {
-            let mut template = String::new();
-            let mut chars = full_text.chars().peekable();
-            let mut placeholder_index = 0;
+        if child_cursor.goto_first_child() {
+            loop {
+                let child = child_cursor.node();
+                if child.kind() == "string_interpolation" {
+                    push_escaped_format_text(&mut value, &source[last_byte..child.start_byte()]);
+                    let mut interpolation_cursor = child.walk();
+                    interpolations.push(read_interpolation(&mut interpolation_cursor, source)?);
+                    value.push_str("{}");
+                    last_byte = child.end_byte();
+                }
 
-            // Skip opening quote
-            if chars.peek() == Some(&'"') {
-                chars.next();
-                template.push('"');
-            }
-
-            while let Some(ch) = chars.next() {
-                if ch == '{' {
-                    // Found interpolation - find the closing brace
-                    let mut expr_content = String::new();
-                    let mut brace_depth = 1;
-
-                    while let Some(inner_ch) = chars.next() {
-                        if inner_ch == '{' {
-                            brace_depth += 1;
-                        } else if inner_ch == '}' {
-                            brace_depth -= 1;
-                            if brace_depth == 0 {
-                                break;
-                            }
-                        }
-                        expr_content.push(inner_ch);
-                    }
-
-                    // Parse arbitrary expressions within interpolations
-                    let expr = parse_interpolation_expression(&expr_content, &span)?;
-                    interpolations.push(expr);
-
-                    // Add placeholder to template
-                    template.push_str(&format!("{{{}}}", placeholder_index));
-                    placeholder_index += 1;
-                } else {
-                    template.push(ch);
+                if !child_cursor.goto_next_sibling() {
+                    break;
                 }
             }
-
-            Ok(Self {
-                value: template,
-                interpolations,
-                span,
-            })
-        } else {
-            // No interpolation - return as-is
-            Ok(Self {
-                value: full_text,
-                interpolations,
-                span,
-            })
         }
+
+        push_escaped_format_text(&mut value, &source[last_byte..node.end_byte()]);
+
+        Ok(Self {
+            value,
+            interpolations,
+            span,
+        })
     }
 }
 

--- a/galvan-test/src/string.galvan
+++ b/galvan-test/src/string.galvan
@@ -1,5 +1,5 @@
 fn greet(name: String) -> String {
-    "Hello, {name}!"
+    "Hello, \(name)!"
 }
 
 test "String interpolation" {
@@ -11,7 +11,7 @@ test "Interpolation with Integers" {
     let x = 3
     let y = 7
     let sum = x + y
-    assert "3 + 7 = 10" == "{x} + {y} = {sum}"
+    assert "3 + 7 = 10" == "\(x) + \(y) = \(sum)"
 }
 
 test "Escaped quotes in strings" {
@@ -28,10 +28,15 @@ test "Escaped quotes in strings" {
 test "Format string with member access" {
     let dog = Dog(name: "Bello", age: 7)
 
-    assert "Hi, {dog.name}!" == "Hi, Bello!"
+    assert "Hi, \(dog.name)!" == "Hi, Bello!"
 }
 
 test "Format string with arithmetic" {
-    assert "3 + 7 = {3 + 7}" == "3 + 7 = 10"
+    assert "3 + 7 = \(3 + 7)" == "3 + 7 = 10"
 }
 
+test "Literal braces in strings" {
+    assert "Set syntax uses { and }" == "Set syntax uses { and }"
+    assert "{\(3 + 7)}" == "{10}"
+    assert "😀" == "\u{1F600}"
+}

--- a/todo.md
+++ b/todo.md
@@ -65,11 +65,6 @@ stored in them.
   - Let users declare `Fn` instead of `FnMut` closures, e.g. for
     multithreading
 
-- **String interpolation** (galvan-into-ast/src/items/literal.rs)
-  - Parse interpolation expressions directly in the grammar instead of
-    re-parsing them with a function wrapper and falling back to verbatim
-    identifiers
-
 - **Tree-sitter grammar completeness** (tree-sitter-galvan/)
   - Add const/async keyword support
   - Replace annotation placeholder with actual implementation


### PR DESCRIPTION
Summary:
- replace brace interpolation syntax with parenthesized interpolation
- parse arbitrary interpolation expressions directly from the syntax tree
- escape literal braces in generated Rust format strings

Verification: cargo test --workspace