### PR TITLE
Use functions for main entry points

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,7 @@ pub enum MyError {
     #[error(transparent)]
     Upstream(#[from] UpstreamError),
 }
+```
+
+### Tree-Sitter Grammar
+For the tree-sitter grammar, you should always directly work on the main branch rather than creating paralell feature branches.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,18 @@ This is where Galvan comes in: It provides a concise syntax and simplified way o
 Galvan is a modern programming language that transpiles to Rust. It provides a concise syntax while leveraging the full power of Rust's ecosystem.
 
 ### Basic Syntax and String Formatting
-In Galvan, `main` is not a function but an "entry point".
+Galvan programs use a regular `main` function.
 ```galvan
-main {
+fn main() {
     let name = "Galvan"
     print("Welcome to {name}, the modern language!")
+}
+```
+The main function can optionally receive the process argument vector. Like C's
+`argv`, the first element is the executable name.
+```galvan
+fn main(args: [String]) {
+    print args
 }
 ```
 Note that Galvan strings always support inline format arguments.
@@ -90,7 +97,7 @@ fn bark(self: Dog) {
     print("{self.name} barks")
 }
 
-main {
+fn main() {
     let dog = Dog(name: "Bello")
     dog.bark()
 }
@@ -105,7 +112,7 @@ type Book {
     content: String = "Lorem ipsum dolor sit amet..."
 }
 
-main {
+fn main() {
     let book = Book()
 }
 ```
@@ -209,7 +216,7 @@ pub type Person {
     ref dog: Dog
 }
 
-main {
+fn main() {
     // Note that constructors use '(' with named arguments
     ref dog = Dog(name: "Bello", age: 5)
     // The `dog` field now points to the same entity as the `dog` variable 
@@ -235,7 +242,7 @@ fn store(ref arg: String) {
     // ...
 }
 
-main {
+fn main() {
     ref my_string = "This is a heap ref"
     
     // Argument must be annotated as mutable
@@ -253,7 +260,7 @@ Only variables and members declared as `ref` can be passed as `ref`
 Ref variables can be assigned to each other by reference
 
 ```galvan
-main {
+fn main() {
     ref msg = "Hello World!"
     ref say = ref msg // now say points to msg
 
@@ -529,7 +536,7 @@ fn add(a: Int, b: Int) -> Int {
     a + b
 }
 
-main {
+fn main() {
     let result = add 2, 3
     print result // 5
 }
@@ -559,15 +566,23 @@ test "Ensure that addition works correctly" {
     assert 2 + 2 == 4
 }
 ```
-Like 'main', 'test' is not a function but an entry point. Tests can take a string as a description. Although this is optional, adding a brief description to your unit tests is highly encouraged.
+Tests can take a string as a description. Although this is optional, adding a brief description to your unit tests is highly encouraged.
 
 ### CLI argument parsing
 Galvan has built-in support for creating CLI apps with arguments and subcommands by integrating the popular *clap* crate.
 This code:
 
 ```galvan
-main {
-    print "Hello World! ..."
+// cmd main arguments are top-level flags rather than a subcommand
+cmd main(
+    /// Optional name to greet when no subcommand is selected
+    n name: String?
+) {
+    try name |name| {
+        print "Hello {name}!"
+    } else {
+        print "Hello World! ..."
+    }
 }
 
 // commands automatically get added to the CLI application as subcommands, including doc comments being shown in the -h argument

--- a/example-projects/cli-app/Cargo.lock
+++ b/example-projects/cli-app/Cargo.lock
@@ -316,6 +316,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "galvan-hir"
+version = "0.0.3"
+dependencies = [
+ "galvan-ast",
+ "galvan-files",
+ "galvan-resolver",
+ "itertools",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "galvan-into-ast"
 version = "0.0.3"
 dependencies = [
@@ -355,6 +366,7 @@ dependencies = [
  "derive_more",
  "galvan-ast",
  "galvan-files",
+ "galvan-hir",
  "galvan-into-ast",
  "galvan-resolver",
  "itertools",

--- a/example-projects/cli-app/src/main.galvan
+++ b/example-projects/cli-app/src/main.galvan
@@ -4,9 +4,9 @@ cmd main(
     n name: String?
 ) {
     try name |name| {
-        print "Hello \(name)!"
+        println "Hello \(name)!"
     } else {
-        print "Hello World! ..."
+        println "Hello World! ..."
     }
 }
 
@@ -22,8 +22,8 @@ cmd greet(
     s surname: String?
 ) {
     try surname |surname| {
-        print "Hello \(name) \(surname)!"
+        println "Hello \(name) \(surname)!"
     } else {
-        print "Hello \(name)!"
+        println "Hello \(name)!"
     }
 }

--- a/example-projects/cli-app/src/main.galvan
+++ b/example-projects/cli-app/src/main.galvan
@@ -14,8 +14,8 @@ cmd greet(
     s surname: String?
 ) {
     try surname |surname| {
-        print "Hello {name} {surname}!"
+        print "Hello \(name) \(surname)!"
     } else {
-        print "Hello {name}!"
+        print "Hello \(name)!"
     }
 }

--- a/example-projects/cli-app/src/main.galvan
+++ b/example-projects/cli-app/src/main.galvan
@@ -1,5 +1,13 @@
-main {
-    print "Hello World! ..."
+// A command named main defines top-level flags instead of a subcommand.
+cmd main(
+    /// Optional name to greet when no subcommand is selected
+    n name: String?
+) {
+    try name |name| {
+        print "Hello {name}!"
+    } else {
+        print "Hello World! ..."
+    }
 }
 
 // commands automatically get added to the CLI application as subcommands, including doc comments being shown in the -h argument

--- a/example-projects/hello-world/src/main.galvan
+++ b/example-projects/hello-world/src/main.galvan
@@ -1,3 +1,3 @@
-main {
+fn main() {
     print "Hello World!"
 }

--- a/galvan-ast/src/item/literal.rs
+++ b/galvan-ast/src/item/literal.rs
@@ -12,7 +12,7 @@ pub type Literal = StringLiteral + NumberLiteral + BooleanLiteral + NoneLiteral 
 #[derive(Clone, Debug, PartialEq, Eq, From)]
 pub struct StringLiteral {
     pub value: String,
-    pub interpolations: Vec<Expression>, // Expressions found in {expr} within the string
+    pub interpolations: Vec<Expression>,
     pub span: Span,
 }
 

--- a/galvan-ast/src/item/toplevel.rs
+++ b/galvan-ast/src/item/toplevel.rs
@@ -1,13 +1,20 @@
 use derive_more::From;
 use galvan_ast_macro::AstNode;
 
-use super::{Body, FnDecl, Ident, ParamList, StringLiteral, TypeDecl};
+use super::{Body, FnDecl, Ident, Param, ParamList, StringLiteral, TypeDecl};
 use crate::{AstNode, PrintAst, Span};
 
-#[derive(Debug, PartialEq, Eq, AstNode)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct MainDecl {
+    pub kind: MainKind,
     pub body: Body,
     pub span: Span,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum MainKind {
+    Function { argument: Option<Param> },
+    Command(CmdSignature),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -23,7 +30,7 @@ pub struct CmdDecl {
     pub span: Span,
 }
 
-#[derive(Debug, PartialEq, Eq, AstNode)]
+#[derive(Clone, Debug, PartialEq, Eq, AstNode)]
 pub struct CmdSignature {
     pub identifier: Ident,
     pub parameters: ParamList,
@@ -41,7 +48,6 @@ pub struct TaskDecl {
 pub enum RootItem {
     Fn(FnDecl),
     Type(TypeDecl),
-    Main(MainDecl),
     Test(TestDecl),
     Cmd(CmdDecl),
     // CustomTask(TaskDecl),

--- a/galvan-examples/function_call.galvan
+++ b/galvan-examples/function_call.galvan
@@ -1,5 +1,5 @@
 fn greet(name: String) {
-    let greetings = "Hello, {name}!"
+    let greetings = "Hello, \(name)!"
     print(greetings)
 }
 

--- a/galvan-hir/src/hir.rs
+++ b/galvan-hir/src/hir.rs
@@ -55,8 +55,15 @@ pub struct HirTest {
 
 #[derive(Debug)]
 pub struct HirMain {
+    pub kind: HirMainKind,
     pub body: HirBlock,
     pub source: Source,
+}
+
+#[derive(Debug)]
+pub enum HirMainKind {
+    Function { argument: Option<Ident> },
+    Command { signature: CmdSignature },
 }
 
 #[derive(Debug)]

--- a/galvan-hir/src/hir.rs
+++ b/galvan-hir/src/hir.rs
@@ -473,7 +473,8 @@ pub enum HirLiteral {
 
 #[derive(Clone, Debug)]
 pub struct HirStringLiteral {
-    /// The raw string literal including quotes and `{}` placeholders
+    /// The Rust format string literal including quotes and `{}` placeholders.
+    /// Literal braces are escaped as `{{` and `}}`.
     pub value: String,
     pub interpolations: Vec<HirExpression>,
 }

--- a/galvan-hir/src/typecheck/expr.rs
+++ b/galvan-hir/src/typecheck/expr.rs
@@ -171,7 +171,7 @@ impl Checker<'_> {
                 let interpolations = string
                     .interpolations
                     .iter()
-                    .map(|interpolation| self.lower_interpolation(interpolation))
+                    .map(|interpolation| self.lower_expression(interpolation, &Expected::free()))
                     .collect();
                 (
                     HirLiteral::String(HirStringLiteral {
@@ -189,28 +189,6 @@ impl Checker<'_> {
             Ownership::UniqueOwned,
             span,
         )
-    }
-
-    /// Lowers a string interpolation argument. When parsing the interpolated
-    /// source failed, the AST falls back to an identifier containing the raw
-    /// expression source (e.g. `dog.name`); such identifiers are rendered
-    /// verbatim instead of being resolved as variables.
-    fn lower_interpolation(&mut self, interpolation: &Expression) -> HirExpression {
-        if let ExpressionKind::Ident(ident) = &interpolation.kind {
-            let is_fallback = ident
-                .as_str()
-                .contains(|c: char| !c.is_alphanumeric() && c != '_');
-            if is_fallback {
-                return HirExpression::new(
-                    HirExpressionKind::Variable(ident.clone()),
-                    TypeElement::infer(),
-                    Ownership::Borrowed,
-                    interpolation.span,
-                );
-            }
-        }
-
-        self.lower_expression(interpolation, &Expected::free())
     }
 
     // ------------------------------------------------------------------

--- a/galvan-hir/src/typecheck/mod.rs
+++ b/galvan-hir/src/typecheck/mod.rs
@@ -11,8 +11,8 @@ mod expr;
 mod scope;
 
 use galvan_ast::{
-    Assignment, AssignmentOperator, Body, DeclModifier, Declaration, FnDecl, Ident, Ownership,
-    SegmentedAsts, Span, Statement, ToplevelItem, TypeElement,
+    Assignment, AssignmentOperator, Body, DeclModifier, Declaration, FnDecl, Ident, MainKind,
+    Ownership, SegmentedAsts, Span, Statement, ToplevelItem, TypeElement,
 };
 use galvan_resolver::{LookupContext, LookupError};
 
@@ -56,9 +56,46 @@ pub fn typecheck(asts: SegmentedAsts) -> Result<(HirModule, ErrorCollector), Loo
             })
             .collect::<Vec<_>>();
 
-        let main = asts.main.as_ref().map(|main| HirMain {
-            body: checker.lower_toplevel_body(&main.item.body),
-            source: main.source.clone(),
+        let main = asts.main.as_ref().map(|main| {
+            checker.scopes.push();
+            let kind = match &main.item.kind {
+                MainKind::Command(signature) => {
+                    for param in &signature.parameters.params {
+                        checker.scopes.declare(Variable {
+                            ident: param.identifier.clone(),
+                            modifier: param.decl_modifier.unwrap_or(DeclModifier::Let),
+                            ty: param.param_type.clone(),
+                            ownership: Ownership::UniqueOwned,
+                        });
+                    }
+                    HirMainKind::Command {
+                        signature: signature.clone(),
+                    }
+                }
+                MainKind::Function { argument } => {
+                    if let Some(argument) = argument {
+                        checker.scopes.declare(Variable {
+                            ident: argument.identifier.clone(),
+                            modifier: DeclModifier::Let,
+                            ty: argument.param_type.clone(),
+                            ownership: Ownership::UniqueOwned,
+                        });
+                    }
+                    HirMainKind::Function {
+                        argument: argument
+                            .as_ref()
+                            .map(|argument| argument.identifier.clone()),
+                    }
+                }
+            };
+            let body = checker.lower_toplevel_body(&main.item.body);
+            checker.scopes.pop();
+
+            HirMain {
+                kind,
+                body,
+                source: main.source.clone(),
+            }
         });
 
         let cmd_bodies = asts

--- a/galvan-into-ast/src/items/literal.rs
+++ b/galvan-into-ast/src/items/literal.rs
@@ -1,84 +1,50 @@
 use galvan_ast::{
-    BooleanLiteral, CharLiteral, Expression, ExpressionKind, Ident, Literal, NoneLiteral,
-    NumberLiteral, Span, StringLiteral,
+    BooleanLiteral, CharLiteral, Expression, Literal, NoneLiteral, NumberLiteral, Span,
+    StringLiteral,
 };
 use galvan_parse::TreeCursor;
 
 use crate::{cursor_expect, result::CursorUtil, AstError, ReadCursor, SpanExt};
 
-// Function to parse an arbitrary expression from string content
-fn parse_interpolation_expression(expr_content: &str, span: &Span) -> Result<Expression, AstError> {
-    // Create a minimal wrapper to parse the expression
-    // We'll wrap it in a simple statement that we can parse
-    let wrapper_source = format!("fn __temp() {{ let __x = {}; }}", expr_content);
-    let source = galvan_files::Source::Str(wrapper_source.clone().into());
+fn push_escaped_format_text(output: &mut String, text: &str) {
+    let mut chars = text.chars().peekable();
 
-    // Parse the wrapper source
-    match galvan_parse::parse_source(&source) {
-        Ok(parsed_tree) => {
-            // Create a cursor from the parsed tree
-            let mut cursor = parsed_tree.root_node().walk();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => {
+                output.push(ch);
+                let Some(escaped) = chars.next() else {
+                    continue;
+                };
+                output.push(escaped);
 
-            // Navigate to find the expression we want
-            // Structure: source -> function -> body -> statement -> declaration -> expression
-            if cursor.child() && // Enter source
-               cursor.child() && // Enter function
-               cursor_goto_named(&mut cursor, "body") &&
-               cursor.child() && // Enter body
-               cursor.child() && // Enter statement
-               cursor_goto_named(&mut cursor, "declaration") &&
-               cursor.child() && // Enter declaration
-               cursor_goto_named(&mut cursor, "expression")
-            {
-                // Found the expression, parse it
-                match Expression::read_cursor(&mut cursor, &wrapper_source) {
-                    Ok(expr) => Ok(expr),
-                    Err(_) => {
-                        // Fallback to creating identifier
-                        create_fallback_expression(expr_content, span)
+                if escaped == 'u' && chars.peek() == Some(&'{') {
+                    for unicode_char in chars.by_ref() {
+                        output.push(unicode_char);
+                        if unicode_char == '}' {
+                            break;
+                        }
                     }
                 }
-            } else {
-                // Navigation failed, create fallback
-                create_fallback_expression(expr_content, span)
             }
-        }
-        Err(_) => {
-            // Parsing failed, create fallback
-            create_fallback_expression(expr_content, span)
+            '{' => output.push_str("{{"),
+            '}' => output.push_str("}}"),
+            _ => output.push(ch),
         }
     }
 }
 
-// Helper function to navigate to a named child node
-fn cursor_goto_named(cursor: &mut TreeCursor<'_>, name: &str) -> bool {
+fn read_interpolation(cursor: &mut TreeCursor<'_>, source: &str) -> Result<Expression, AstError> {
+    cursor_expect!(cursor, "string_interpolation");
+    cursor.child();
+
     loop {
-        if cursor.kind().unwrap_or("") == name {
-            return true;
+        if cursor.kind()? == "expression" {
+            return Expression::read_cursor(cursor, source);
         }
-        if !cursor.goto_next_sibling() {
-            return false;
+        if !cursor.next() {
+            return Err(AstError::ConversionError);
         }
-    }
-}
-
-// Helper function to create fallback expressions
-fn create_fallback_expression(expr_content: &str, span: &Span) -> Result<Expression, AstError> {
-    if expr_content
-        .chars()
-        .all(|c| c.is_alphanumeric() || c == '_')
-    {
-        // Simple identifier
-        Ok(Expression {
-            kind: ExpressionKind::Ident(Ident::new(expr_content)),
-            span: span.clone(),
-        })
-    } else {
-        // Treat as identifier anyway - let the transpiler handle complex syntax
-        Ok(Expression {
-            kind: ExpressionKind::Ident(Ident::new(expr_content)),
-            span: span.clone(),
-        })
     }
 }
 
@@ -134,65 +100,35 @@ impl ReadCursor for StringLiteral {
     fn read_cursor(cursor: &mut TreeCursor<'_>, source: &str) -> Result<Self, AstError> {
         let node = cursor_expect!(cursor, "string_literal");
         let span = Span::from_node(node);
-        let full_text = source[node.start_byte()..node.end_byte()].to_owned();
-
+        let mut value = String::new();
         let mut interpolations = Vec::new();
+        let mut last_byte = node.start_byte();
+        let mut child_cursor = node.walk();
 
-        // Simple approach: manually parse the string and replace interpolations with placeholders
-        if full_text.contains('{') && full_text.contains('}') {
-            let mut template = String::new();
-            let mut chars = full_text.chars().peekable();
-            let mut placeholder_index = 0;
+        if child_cursor.goto_first_child() {
+            loop {
+                let child = child_cursor.node();
+                if child.kind() == "string_interpolation" {
+                    push_escaped_format_text(&mut value, &source[last_byte..child.start_byte()]);
+                    let mut interpolation_cursor = child.walk();
+                    interpolations.push(read_interpolation(&mut interpolation_cursor, source)?);
+                    value.push_str("{}");
+                    last_byte = child.end_byte();
+                }
 
-            // Skip opening quote
-            if chars.peek() == Some(&'"') {
-                chars.next();
-                template.push('"');
-            }
-
-            while let Some(ch) = chars.next() {
-                if ch == '{' {
-                    // Found interpolation - find the closing brace
-                    let mut expr_content = String::new();
-                    let mut brace_depth = 1;
-
-                    while let Some(inner_ch) = chars.next() {
-                        if inner_ch == '{' {
-                            brace_depth += 1;
-                        } else if inner_ch == '}' {
-                            brace_depth -= 1;
-                            if brace_depth == 0 {
-                                break;
-                            }
-                        }
-                        expr_content.push(inner_ch);
-                    }
-
-                    // Parse arbitrary expressions within interpolations
-                    let expr = parse_interpolation_expression(&expr_content, &span)?;
-                    interpolations.push(expr);
-
-                    // Add placeholder to template
-                    template.push_str(&format!("{{{}}}", placeholder_index));
-                    placeholder_index += 1;
-                } else {
-                    template.push(ch);
+                if !child_cursor.goto_next_sibling() {
+                    break;
                 }
             }
-
-            Ok(Self {
-                value: template,
-                interpolations,
-                span,
-            })
-        } else {
-            // No interpolation - return as-is
-            Ok(Self {
-                value: full_text,
-                interpolations,
-                span,
-            })
         }
+
+        push_escaped_format_text(&mut value, &source[last_byte..node.end_byte()]);
+
+        Ok(Self {
+            value,
+            interpolations,
+            span,
+        })
     }
 }
 

--- a/galvan-into-ast/src/items/toplevel.rs
+++ b/galvan-into-ast/src/items/toplevel.rs
@@ -1,8 +1,7 @@
 use galvan_ast::{
     AliasTypeDecl, Body, CmdDecl, CmdSignature, DeclModifier, EmptyTypeDecl, EnumTypeDecl, FnDecl,
-    FnSignature, Ident, MainDecl, Param, ParamList, RootItem, Span, Statement, StringLiteral,
-    StructTypeDecl, TestDecl, TupleTypeDecl, TypeDecl, TypeElement, TypeIdent, Visibility,
-    WhereBound, WhereClause,
+    FnSignature, Ident, Param, ParamList, RootItem, Span, Statement, StringLiteral, StructTypeDecl,
+    TestDecl, TupleTypeDecl, TypeDecl, TypeElement, TypeIdent, Visibility, WhereBound, WhereClause,
 };
 use galvan_parse::TreeCursor;
 
@@ -11,33 +10,13 @@ use crate::{cursor_expect, result::CursorUtil, AstError, ReadCursor, SpanExt};
 impl ReadCursor for RootItem {
     fn read_cursor(cursor: &mut TreeCursor<'_>, source: &str) -> Result<Self, AstError> {
         Ok(match cursor.kind()? {
-            "main" => MainDecl::read_cursor(cursor, source)?.into(),
             "build" => todo!("Implement build entry point!"),
             "test" => TestDecl::read_cursor(cursor, source)?.into(),
             "function" => FnDecl::read_cursor(cursor, source)?.into(),
             "cmd" => CmdDecl::read_cursor(cursor, source)?.into(),
             "type_declaration" => TypeDecl::read_cursor(cursor, source)?.into(),
-            "entry_point" => todo!("Implement custom tasks!"),
             other => unreachable!("Unexpected node in root item: {other}"),
         })
-    }
-}
-
-impl ReadCursor for MainDecl {
-    fn read_cursor(cursor: &mut TreeCursor<'_>, source: &str) -> Result<Self, AstError> {
-        let main = cursor_expect!(cursor, "main");
-        let span = Span::from_node(main);
-        cursor.child();
-        cursor_expect!(cursor, "main_keyword");
-
-        cursor.next();
-        let body = Body::read_cursor(cursor, source)?;
-
-        assert!(!cursor.next(), "Unexpected token in main");
-
-        cursor.goto_parent();
-
-        Ok(MainDecl { body, span })
     }
 }
 

--- a/galvan-into-ast/src/lib.rs
+++ b/galvan-into-ast/src/lib.rs
@@ -1,4 +1,7 @@
-use galvan_ast::{Ast, Point, RootItem, SegmentedAsts, Span, ToplevelItem};
+use galvan_ast::{
+    Ast, FnDecl, MainDecl, MainKind, Point, RootItem, SegmentedAsts, Span, ToplevelItem,
+    TypeElement, VisibilityKind,
+};
 use galvan_files::Source;
 use galvan_parse::*;
 
@@ -73,6 +76,16 @@ impl SegmentAst for Ast {
                     item,
                     source: self.source.clone(),
                 }),
+                RootItem::Fn(item) if item.signature.identifier.as_str() == "main" => {
+                    if main.is_some() {
+                        return Err(AstError::DuplicateMain);
+                    }
+
+                    main = Some(ToplevelItem {
+                        item: main_decl(item)?,
+                        source: self.source.clone(),
+                    });
+                }
                 RootItem::Fn(item) => functions.push(ToplevelItem {
                     item,
                     source: self.source.clone(),
@@ -81,15 +94,19 @@ impl SegmentAst for Ast {
                     item,
                     source: self.source.clone(),
                 }),
-                RootItem::Main(item) => {
+                RootItem::Cmd(item) if item.signature.identifier.as_str() == "main" => {
                     if main.is_some() {
                         return Err(AstError::DuplicateMain);
                     }
 
                     main = Some(ToplevelItem {
-                        item,
+                        item: MainDecl {
+                            kind: MainKind::Command(item.signature),
+                            body: item.body,
+                            span: item.span,
+                        },
                         source: self.source.clone(),
-                    })
+                    });
                 }
                 RootItem::Cmd(item) => cmds.push(ToplevelItem {
                     item,
@@ -106,6 +123,44 @@ impl SegmentAst for Ast {
             cmds,
         })
     }
+}
+
+fn main_decl(function: FnDecl) -> Result<MainDecl, AstError> {
+    let FnDecl {
+        signature,
+        body,
+        span,
+    } = function;
+    let mut parameters = signature.parameters.params.into_iter();
+    let argument = parameters.next();
+
+    let valid_argument = argument.as_ref().is_none_or(|parameter| {
+        parameter.decl_modifier.is_none()
+            && parameter.short_name.is_none()
+            && matches!(
+                &parameter.param_type,
+                TypeElement::Array(array)
+                    if matches!(
+                        &array.elements,
+                        TypeElement::Plain(string) if string.ident.as_str() == "String"
+                    )
+            )
+    });
+    let valid_signature = parameters.next().is_none()
+        && valid_argument
+        && signature.visibility.kind == VisibilityKind::Inherited
+        && matches!(signature.return_type, TypeElement::Void(_))
+        && signature.where_clause.is_none();
+
+    if !valid_signature {
+        return Err(AstError::InvalidMainSignature);
+    }
+
+    Ok(MainDecl {
+        kind: MainKind::Function { argument },
+        body,
+        span,
+    })
 }
 
 impl SegmentAst for Vec<Ast> {

--- a/galvan-into-ast/src/result.rs
+++ b/galvan-into-ast/src/result.rs
@@ -15,6 +15,8 @@ pub enum AstError {
     NodeError,
     #[error("Duplicate main function")]
     DuplicateMain,
+    #[error("Main must have signature `fn main()` or `fn main(args: [String])`")]
+    InvalidMainSignature,
     #[error("Invalid character literal at {0:?}")]
     InvalidCharacterLiteral(Span),
     #[error(transparent)]

--- a/galvan-resolver/src/lookup.rs
+++ b/galvan-resolver/src/lookup.rs
@@ -1,6 +1,4 @@
-use galvan_ast::{
-    FnDecl, Ident, MainDecl, SegmentedAsts, ToplevelItem, TypeDecl, TypeElement, TypeIdent,
-};
+use galvan_ast::{FnDecl, Ident, SegmentedAsts, ToplevelItem, TypeDecl, TypeElement, TypeIdent};
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -16,7 +14,6 @@ pub struct LookupContext<'a> {
     pub functions: HashMap<FunctionId, &'a ToplevelItem<FnDecl>>,
     // TODO: Nested contexts for resolving names from imported modules
     // pub imports: HashMap<String, LookupContext<'a>>,
-    pub main: Option<&'a ToplevelItem<MainDecl>>,
 }
 
 pub trait Lookup {

--- a/galvan-test/src/string.galvan
+++ b/galvan-test/src/string.galvan
@@ -1,5 +1,5 @@
 fn greet(name: String) -> String {
-    "Hello, {name}!"
+    "Hello, \(name)!"
 }
 
 test "String interpolation" {
@@ -11,7 +11,7 @@ test "Interpolation with Integers" {
     let x = 3
     let y = 7
     let sum = x + y
-    assert "3 + 7 = 10" == "{x} + {y} = {sum}"
+    assert "3 + 7 = 10" == "\(x) + \(y) = \(sum)"
 }
 
 test "Escaped quotes in strings" {
@@ -28,10 +28,15 @@ test "Escaped quotes in strings" {
 test "Format string with member access" {
     let dog = Dog(name: "Bello", age: 7)
 
-    assert "Hi, {dog.name}!" == "Hi, Bello!"
+    assert "Hi, \(dog.name)!" == "Hi, Bello!"
 }
 
 test "Format string with arithmetic" {
-    assert "3 + 7 = {3 + 7}" == "3 + 7 = 10"
+    assert "3 + 7 = \(3 + 7)" == "3 + 7 = 10"
 }
 
+test "Literal braces in strings" {
+    assert "Set syntax uses { and }" == "Set syntax uses { and }"
+    assert "{\(3 + 7)}" == "{10}"
+    assert "😀" == "\u{1F600}"
+}

--- a/galvan-transpiler/src/codegen/function.rs
+++ b/galvan-transpiler/src/codegen/function.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use galvan_ast::{CmdSignature, DeclModifier, FnSignature, Ident, Param, TypeElement};
 use galvan_hir::builtins::CheckBuiltins;
-use galvan_hir::hir::{HirFunction, HirMain, HirTest};
+use galvan_hir::hir::{HirFunction, HirMain, HirMainKind, HirTest};
 use itertools::Itertools;
 
 use crate::context::Context;
@@ -179,7 +179,36 @@ pub(crate) fn transpile_test(
 
 pub(crate) fn transpile_main(main: &HirMain, ctx: &Context, errors: &mut ErrorCollector) -> String {
     let body = main.body.transpile(ctx, errors);
-    format!("pub(crate) fn __main__() {body}")
+    match &main.kind {
+        HirMainKind::Function { argument: None } => {
+            format!("pub(crate) fn __main__() {body}")
+        }
+        HirMainKind::Function {
+            argument: Some(argument),
+        } => {
+            let argument = sanitize_name(argument.as_str());
+            format!(
+                "pub(crate) fn __main__() {{ let {argument}: ::std::vec::Vec<String> = ::std::env::args().collect(); {body}; }}"
+            )
+        }
+        HirMainKind::Command { signature } => {
+            let parameters = signature
+                .parameters
+                .params
+                .iter()
+                .map(|param| {
+                    format!(
+                        "{}: {}",
+                        sanitize_name(param.identifier.as_str()),
+                        param.param_type.transpile(ctx, errors)
+                    )
+                })
+                .join(", ");
+            format!(
+                "pub(crate) fn __main__() {{ unreachable!(\"CLI entry point dispatches through __cli_main\") }}\nfn __main_command({parameters}) {body}"
+            )
+        }
+    }
 }
 
 impl Transpile for CmdSignature {

--- a/galvan-transpiler/src/lib.rs
+++ b/galvan-transpiler/src/lib.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 use galvan_ast::*;
 use galvan_files::{FileError, Source};
-use galvan_hir::hir::{HirCmd, HirFunction, HirModule, HirTest};
+use galvan_hir::hir::{HirCmd, HirFunction, HirMain, HirMainKind, HirModule, HirTest};
 use galvan_hir::typecheck::typecheck;
 use galvan_into_ast::{AstError, SegmentAst, SourceIntoAst};
 use galvan_resolver::LookupError;
@@ -90,9 +90,59 @@ fn extract_param_doc_comment(source_content: &str, param: &Param) -> Option<Stri
     extract_doc_comment(source_content, &param.span)
 }
 
-/// Generate CLI structure with subcommands
+struct CliArguments {
+    fields: Vec<String>,
+    values: Vec<String>,
+}
+
+fn cli_arguments(
+    parameters: &ParamList,
+    source: &Source,
+    ctx: &Context,
+    errors: &mut ErrorCollector,
+) -> CliArguments {
+    let mut fields = Vec::new();
+    let mut values = Vec::new();
+
+    for param in &parameters.params {
+        let field_name = param.identifier.as_str();
+        let param_type = param.param_type.transpile(ctx, errors);
+        let help_text = extract_param_doc_comment(source.content(), param);
+        let clap_attr = match (&param.short_name, &help_text) {
+            (Some(short_name), Some(help)) => {
+                format!(
+                    "#[arg(short = '{}', long = \"{}\", help = \"{}\")]",
+                    short_name.as_str(),
+                    field_name,
+                    help
+                )
+            }
+            (Some(short_name), None) => {
+                format!(
+                    "#[arg(short = '{}', long = \"{}\")]",
+                    short_name.as_str(),
+                    field_name
+                )
+            }
+            (None, Some(help)) => {
+                format!("#[arg(long = \"{}\", help = \"{}\")]", field_name, help)
+            }
+            (None, None) => format!("#[arg(long = \"{}\")]", field_name),
+        };
+
+        fields.push(format!(
+            "    {clap_attr}\n    pub {field_name}: {param_type}"
+        ));
+        values.push(field_name.to_owned());
+    }
+
+    CliArguments { fields, values }
+}
+
+/// Generate CLI structure with top-level arguments and subcommands.
 fn generate_cli_structure(
     commands: &[HirCmd],
+    main: Option<&HirMain>,
     ctx: &Context,
     errors: &mut ErrorCollector,
 ) -> (String, String) {
@@ -111,49 +161,9 @@ fn generate_cli_structure(
         command_functions.push(format!("{signature} {body}"));
 
         // Generate args struct for this command
-        let mut args_fields = Vec::new();
-        let mut function_params = Vec::new();
+        let arguments = cli_arguments(&cmd.signature.parameters, &cmd.source, ctx, errors);
 
-        for param in &cmd.signature.parameters.params {
-            let field_name = param.identifier.as_str();
-            let param_type = param.param_type.transpile(ctx, errors);
-
-            // Extract doc comment for this parameter
-            let help_text = extract_param_doc_comment(cmd.source.content(), param);
-
-            // Generate clap attribute based on short_name and help text
-            let clap_attr = match (&param.short_name, &help_text) {
-                (Some(short_name), Some(help)) => {
-                    format!(
-                        "#[arg(short = '{}', long = \"{}\", help = \"{}\")]",
-                        short_name.as_str(),
-                        field_name,
-                        help
-                    )
-                }
-                (Some(short_name), None) => {
-                    format!(
-                        "#[arg(short = '{}', long = \"{}\")]",
-                        short_name.as_str(),
-                        field_name
-                    )
-                }
-                (None, Some(help)) => {
-                    format!("#[arg(long = \"{}\", help = \"{}\")]", field_name, help)
-                }
-                (None, None) => {
-                    format!("#[arg(long = \"{}\")]", field_name)
-                }
-            };
-
-            args_fields.push(format!(
-                "    {}\n    pub {}: {}",
-                clap_attr, field_name, param_type
-            ));
-            function_params.push(format!("args.{}", field_name));
-        }
-
-        let args_struct = if args_fields.is_empty() {
+        let args_struct = if arguments.fields.is_empty() {
             format!(
                 "#[derive(clap::Args, Debug)]\nstruct {}Args {{}}",
                 cmd_name_pascal
@@ -162,7 +172,7 @@ fn generate_cli_structure(
             format!(
                 "#[derive(clap::Args, Debug)]\nstruct {}Args {{\n{}\n}}",
                 cmd_name_pascal,
-                args_fields.join(",\n")
+                arguments.fields.join(",\n")
             )
         };
 
@@ -183,10 +193,18 @@ fn generate_cli_structure(
         subcommand_variants.push(variant);
 
         // Generate match arm
-        let function_call = if function_params.is_empty() {
+        let function_call = if arguments.values.is_empty() {
             format!("{}()", cmd_name)
         } else {
-            format!("{}({})", cmd_name, function_params.join(", "))
+            format!(
+                "{}({})",
+                cmd_name,
+                arguments
+                    .values
+                    .iter()
+                    .map(|field| format!("args.{field}"))
+                    .join(", ")
+            )
         };
 
         match_arms.push(format!(
@@ -195,13 +213,67 @@ fn generate_cli_structure(
         ));
     }
 
-    let cli_code = format!(
-        r#"
-use clap::{{Parser, Subcommand, Args}};
+    let main_arguments = match main {
+        Some(HirMain {
+            kind: HirMainKind::Command { signature },
+            source,
+            ..
+        }) => Some(cli_arguments(&signature.parameters, source, ctx, errors)),
+        _ => None,
+    };
+    let main_call = match &main_arguments {
+        Some(arguments) if arguments.values.is_empty() => "__main_command()".to_owned(),
+        Some(arguments) => format!("__main_command({})", arguments.values.join(", ")),
+        None if main.is_some() => "__main__()".to_owned(),
+        None => "{}".to_owned(),
+    };
+    let main_fields = main_arguments
+        .as_ref()
+        .map(|arguments| arguments.fields.join(",\n"))
+        .unwrap_or_default();
+    let main_bindings = main_arguments
+        .as_ref()
+        .map(|arguments| arguments.values.join(", "))
+        .unwrap_or_default();
+    let cli_bindings = if main_bindings.is_empty() {
+        "command".to_owned()
+    } else {
+        format!("{main_bindings}, command")
+    };
+
+    let cli_code = if commands.is_empty() {
+        format!(
+            r#"
+use clap::Parser;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {{
+{main_fields}
+}}
+
+pub(crate) fn __cli_main() {{
+    let cli = Cli::parse();
+    let Cli {{ {} }} = cli;
+    {main_call};
+}}
+"#,
+            main_bindings
+        )
+    } else {
+        let main_fields = if main_fields.is_empty() {
+            String::new()
+        } else {
+            format!("{main_fields},")
+        };
+        format!(
+            r#"
+use clap::{{Parser, Subcommand, Args}};
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None, subcommand_negates_reqs = true)]
+struct Cli {{
+{main_fields}
     #[command(subcommand)]
     command: Option<Commands>,
 }}
@@ -214,17 +286,18 @@ enum Commands {{
 {}
 
 pub(crate) fn __cli_main() {{
-    let cli = Cli::parse();
-    match cli.command {{
+    let Cli {{ {cli_bindings} }} = Cli::parse();
+    match command {{
 {}
-        None => __main__(),
+        None => {main_call},
     }}
 }}
 "#,
-        subcommand_variants.join(",\n"),
-        subcommand_args.join("\n\n"),
-        match_arms.join("\n")
-    );
+            subcommand_variants.join(",\n"),
+            subcommand_args.join("\n\n"),
+            match_arms.join("\n")
+        )
+    };
 
     (command_functions.join("\n\n"), cli_code)
 }
@@ -382,10 +455,21 @@ fn transpile_module(
         .main
         .as_ref()
         .map(|main| transpile_main(main, ctx, errors))
-        .unwrap_or_default();
+        .unwrap_or_else(|| {
+            if module.cmds.is_empty() {
+                String::new()
+            } else {
+                "pub(crate) fn __main__() { unreachable!(\"No default main command\") }".to_owned()
+            }
+        });
 
-    let (cmds, cli_main) = if !module.cmds.is_empty() {
-        let (command_functions, cli_code) = generate_cli_structure(&module.cmds, ctx, errors);
+    let has_command_main = module
+        .main
+        .as_ref()
+        .is_some_and(|main| matches!(&main.kind, HirMainKind::Command { .. }));
+    let (cmds, cli_main) = if !module.cmds.is_empty() || has_command_main {
+        let (command_functions, cli_code) =
+            generate_cli_structure(&module.cmds, module.main.as_ref(), ctx, errors);
         (command_functions, cli_code)
     } else {
         (
@@ -398,7 +482,7 @@ fn transpile_module(
         )
     };
 
-    let has_cli_commands = !module.cmds.is_empty();
+    let has_cli_commands = !module.cmds.is_empty() || has_command_main;
     let cli_flag = if has_cli_commands {
         "pub(crate) const __HAS_CLI_COMMANDS: bool = true;"
     } else {

--- a/galvan-transpiler/test-cases/inference/vec.galvan
+++ b/galvan-transpiler/test-cases/inference/vec.galvan
@@ -5,6 +5,6 @@
 //} pub(crate) fn __cli_main() { unreachable!(\"This is not a CLI app.\") }"
 //@end
 
-main {
+fn main() {
     let a = [1, 2, 3]
 }

--- a/galvan-transpiler/tests/test_transpilation.rs
+++ b/galvan-transpiler/tests/test_transpilation.rs
@@ -60,3 +60,65 @@ generate_code_tests!(test_transpilation, TRANSPILE, trim_all {
     let transpilation = transpile(vec![source]).unwrap();
     merge_outputs(transpilation)
 });
+
+fn transpile_source(code: &str) -> String {
+    transpile(vec![Source::from_string(code)])
+        .unwrap()
+        .into_iter()
+        .map(|output| output.content.to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn transpiles_main_as_a_normal_function() {
+    let output = transpile_source("fn main() { print \"Hello\" }");
+
+    assert!(output.contains("pub(crate) fn __main__()"));
+    assert!(!output.contains("std::env::args()"));
+}
+
+#[test]
+fn collects_argv_for_main_function_argument() {
+    let output = transpile_source("fn main(args: [String]) { print args }");
+
+    assert!(output.contains("let args: ::std::vec::Vec<String> = ::std::env::args().collect()"));
+}
+
+#[test]
+fn transpiles_command_main_arguments_as_top_level_flags() {
+    let output = transpile_source(
+        "cmd main(
+            n name: String,
+            count: Int?
+        ) {
+            print name
+        }",
+    );
+
+    assert!(output.contains("fn __main_command(name: String, count: Option<i64>)"));
+    assert!(output.contains("pub name: String"));
+    assert!(output.contains("pub count: Option<i64>"));
+    assert!(output.contains("let Cli { name, count } = cli"));
+    assert!(output.contains("__main_command(name, count)"));
+    assert!(!output.contains("enum Commands"));
+}
+
+#[test]
+fn command_main_coexists_with_subcommands() {
+    let output = transpile_source(
+        "cmd main(verbose: Bool?) {}
+         cmd greet(name: String) { print name }",
+    );
+
+    assert!(output.contains("subcommand_negates_reqs = true"));
+    assert!(output.contains("enum Commands"));
+    assert!(output.contains("None => __main_command(verbose)"));
+}
+
+#[test]
+fn rejects_invalid_main_function_signatures() {
+    assert!(transpile(vec![Source::from_string("fn main(value: Int) {}")]).is_err());
+    assert!(transpile(vec![Source::from_string("main {}")]).is_err());
+    assert!(transpile(vec![Source::from_string("fn main() {} cmd main() {}")]).is_err());
+}

--- a/todo.md
+++ b/todo.md
@@ -65,11 +65,6 @@ stored in them.
   - Let users declare `Fn` instead of `FnMut` closures, e.g. for
     multithreading
 
-- **String interpolation** (galvan-into-ast/src/items/literal.rs)
-  - Parse interpolation expressions directly in the grammar instead of
-    re-parsing them with a function wrapper and falling back to verbatim
-    identifiers
-
 - **Tree-sitter grammar completeness** (tree-sitter-galvan/)
   - Add const/async keyword support
   - Replace annotation placeholder with actual implementation

--- a/todo.md
+++ b/todo.md
@@ -73,8 +73,6 @@ commands remain subcommands.
   - Add const/async keyword support
   - Replace annotation placeholder with actual implementation
   - Add implicit closure parameter rules
-  - Move literal corpus fixtures into a valid top-level context; bare literals
-    currently parse as errors because `source` only accepts top-level items
 
 ## Future Enhancements
 

--- a/todo.md
+++ b/todo.md
@@ -8,6 +8,10 @@ HIR (`galvan-hir/src/typecheck/`) and mechanical code generation from the HIR
 belong in the typechecker; codegen only renders nodes and the adjustments
 stored in them.
 
+Program entry points are declared as `fn main()`, `fn main(args: [String])`,
+or `cmd main(...)`. The latter supplies top-level CLI flags while other
+commands remain subcommands.
+
 ## Critical - Core Language Features
 
 - **Typechecker improvements** (galvan-hir/src/typecheck/)


### PR DESCRIPTION
## Summary
- replace the special main block syntax with fn main()
- support fn main(args: [String]) using the process argument vector
- support cmd main(...) as top-level CLI flags while other commands remain subcommands
- reject invalid or duplicate main entry points
- update grammar, generated parser, docs, examples, and transpilation tests

## Verification
- cargo test --workspace
- cargo check for hello-world and cli-app examples
- exercised cli-app with top-level flags and a subcommand