### PR TITLE
Complete control-flow lowering

### DIFF
--- a/galvan-hir/src/hir.rs
+++ b/galvan-hir/src/hir.rs
@@ -327,13 +327,21 @@ pub struct HirIf {
 /// surrounding context.
 #[derive(Clone, Debug)]
 pub struct HirElseUnwrap {
+    pub kind: HirElseUnwrapKind,
     pub receiver: HirExpression,
     /// Bind with a `ref` pattern (`Some(ref __value)`) to avoid moving out of
     /// a receiver that is used again later
     pub by_ref: bool,
     /// The unwrapped value (a `__value` variable with coercion adjustments)
     pub value: HirExpression,
+    pub err_binding: Option<Ident>,
     pub else_block: HirBlock,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HirElseUnwrapKind {
+    Optional,
+    Result,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -358,15 +366,28 @@ pub struct HirTry {
 
 #[derive(Clone, Debug)]
 pub struct HirFor {
-    /// Loop variables; the implicit `it` parameter is materialized here
-    pub bindings: Vec<Ident>,
-    /// Destructure the loop reference with a `&` pattern (used for `Copy` elements)
-    pub bind_by_ref: bool,
+    /// Loop variables; the implicit `it` parameter is materialized here.
+    pub bindings: Vec<HirForBinding>,
+    pub iterable_kind: HirForIterableKind,
     pub iterable: HirExpression,
     pub body: HirBlock,
     /// `Some(element_type)` when the loop is used as an expression and
     /// collects the value of each iteration into a vector
     pub collect: Option<TypeElement>,
+}
+
+#[derive(Clone, Debug)]
+pub struct HirForBinding {
+    pub ident: Ident,
+    /// Destructure this binding with a `&` pattern when iterating borrowed
+    /// collections of `Copy` values.
+    pub deref: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HirForIterableKind {
+    Normal,
+    Tuple { len: usize },
 }
 
 #[derive(Clone, Debug)]

--- a/galvan-hir/src/typecheck/expr.rs
+++ b/galvan-hir/src/typecheck/expr.rs
@@ -12,7 +12,7 @@ use galvan_ast::{
 use galvan_resolver::Lookup;
 
 use crate::builtins::{CheckBuiltins, BORROWED_ITERATOR_FNS};
-use crate::error::TranspilerError;
+use crate::error::{ErrorCollector, TranspilerError};
 use crate::hir::*;
 
 use super::{concat_kind, types_compatible, Checker, Expected, Variable};
@@ -1198,9 +1198,16 @@ impl Checker<'_> {
     ) -> HirExpression {
         let receiver = self.lower_expression(&else_expression.receiver, &Expected::free());
 
-        let inner_ty = match &receiver.ty {
-            TypeElement::Optional(optional) => optional.inner.clone(),
-            other => other.clone(),
+        let (kind, inner_ty, err_ty) = match &receiver.ty {
+            TypeElement::Optional(optional) => {
+                (HirElseUnwrapKind::Optional, optional.inner.clone(), None)
+            }
+            TypeElement::Result(result) => (
+                HirElseUnwrapKind::Result,
+                result.success.clone(),
+                Some(result.error.clone().unwrap_or_else(TypeElement::infer)),
+            ),
+            other => (HirElseUnwrapKind::Optional, other.clone(), None),
         };
 
         let value_expected = if expected.is_free() || expected.is_void() {
@@ -1232,7 +1239,22 @@ impl Checker<'_> {
         let value = self.coerce(value, &value_expected);
         self.scopes.pop();
 
+        self.scopes.push();
+        let err_binding = else_unwrap_err_parameter(else_expression, err_ty.as_ref());
+        if let Some((ident, ty)) = &err_binding {
+            self.scopes.declare(Variable {
+                ident: ident.clone(),
+                modifier: DeclModifier::Let,
+                ty: ty.clone(),
+                ownership: if self.is_copy(ty) {
+                    Ownership::UniqueOwned
+                } else {
+                    Ownership::Borrowed
+                },
+            });
+        }
         let else_block = self.lower_block(&else_expression.block.body, &value_expected);
+        self.scopes.pop();
 
         let ty = if value_expected.is_free() {
             inner_ty
@@ -1242,9 +1264,11 @@ impl Checker<'_> {
 
         HirExpression::new(
             HirExpressionKind::ElseUnwrap(Box::new(HirElseUnwrap {
+                kind,
                 receiver,
                 by_ref,
                 value,
+                err_binding: err_binding.map(|(ident, _)| ident),
                 else_block,
             })),
             ty,
@@ -1417,17 +1441,17 @@ impl Checker<'_> {
                 let condition = self.coerce_unknown_argument(condition);
 
                 self.scopes.push();
-                let ok_bindings = body
-                    .parameters
-                    .iter()
-                    .map(|parameter| {
+                let ok_parameters = try_ok_parameters(body, &ok_ty);
+                let ok_bindings = ok_parameters
+                    .into_iter()
+                    .map(|(ident, ty)| {
                         self.scopes.declare(Variable {
-                            ident: parameter.ident.clone(),
+                            ident: ident.clone(),
                             modifier: DeclModifier::Let,
-                            ty: ok_ty.clone(),
+                            ty,
                             ownership: Ownership::Borrowed,
                         });
-                        parameter.ident.clone()
+                        ident
                     })
                     .collect();
                 let block = self.lower_block(&body.block.body, &Expected::free());
@@ -1500,33 +1524,32 @@ impl Checker<'_> {
 
         self.scopes.push();
         let ok_ownership = binding_ownership(self, &ok_ty, scrutinee_ownership);
-        let ok_bindings: Vec<Ident> = body
-            .parameters
-            .iter()
-            .map(|parameter| {
+        let ok_parameters = try_ok_parameters(body, &ok_ty);
+        let ok_bindings: Vec<Ident> = ok_parameters
+            .into_iter()
+            .map(|(ident, ty)| {
                 self.scopes.declare(Variable {
-                    ident: parameter.ident.clone(),
+                    ident: ident.clone(),
                     modifier: DeclModifier::Let,
-                    ty: ok_ty.clone(),
+                    ty,
                     ownership: ok_ownership,
                 });
-                parameter.ident.clone()
+                ident
             })
             .collect();
         let block = self.lower_block(&body.block.body, &branch_expected);
         self.scopes.pop();
 
         self.scopes.push();
-        let err_binding = else_expression.parameters.first().map(|parameter| {
-            let err_ty = err_ty.clone().unwrap_or_else(TypeElement::infer);
-            let err_ownership = binding_ownership(self, &err_ty, scrutinee_ownership);
+        let err_binding = try_err_parameter(else_expression, err_ty.as_ref()).map(|(ident, ty)| {
+            let err_ownership = binding_ownership(self, &ty, scrutinee_ownership);
             self.scopes.declare(Variable {
-                ident: parameter.ident.clone(),
+                ident: ident.clone(),
                 modifier: DeclModifier::Let,
-                ty: err_ty,
+                ty,
                 ownership: err_ownership,
             });
-            parameter.ident.clone()
+            ident
         });
         let else_block = self.lower_block(&else_expression.block.body, &branch_expected);
         self.scopes.pop();
@@ -1569,27 +1592,7 @@ impl Checker<'_> {
         };
 
         let iterable = self.lower_expression(&call.arguments[0].expression, &Expected::free());
-
-        let elem_ty = match &iterable.ty {
-            TypeElement::Array(array) => array.elements.clone(),
-            TypeElement::Set(set) => set.elements.clone(),
-            TypeElement::Dictionary(_) | TypeElement::OrderedDictionary(_) => {
-                self.errors.warning(
-                    "For loop on dictionary not yet implemented".to_string(),
-                    None,
-                );
-                TypeElement::infer()
-            }
-            TypeElement::Tuple(_) | TypeElement::Optional(_) | TypeElement::Result(_) => {
-                TypeElement::infer()
-            }
-            TypeElement::Infer(_) | TypeElement::Void(_) => TypeElement::infer(),
-            _ => {
-                self.errors
-                    .warning("For loop on type that is not an iterator".to_string(), None);
-                TypeElement::infer()
-            }
-        };
+        let iterable_info = self.for_iterable_info(&iterable.ty);
 
         // Borrow iterated locals so the loop does not consume them
         let iterable = match (&iterable.kind, iterable.adjusted_ownership()) {
@@ -1602,8 +1605,10 @@ impl Checker<'_> {
             _ => iterable,
         };
 
-        let is_range = matches!(iterable.kind, HirExpressionKind::Range(_));
-        let bind_by_ref = self.is_copy(&elem_ty) && !is_range && !elem_ty.is_infer();
+        let borrows_iterable = matches!(
+            iterable.adjusted_ownership(),
+            Ownership::Borrowed | Ownership::MutBorrowed
+        );
 
         let collect = if expected.is_void() {
             None
@@ -1611,33 +1616,45 @@ impl Checker<'_> {
             Some(iteration_type(&self.fn_return, &expected.ty))
         };
 
-        let element_ownership = if self.is_copy(&elem_ty) {
-            Ownership::UniqueOwned
-        } else {
-            Ownership::Borrowed
-        };
-
         self.scopes.push();
-        let bindings: Vec<Ident> = if body.parameters.is_empty() {
+        let bindings: Vec<HirForBinding> = if body.parameters.is_empty() {
             // Implicit `it` parameter
+            let binding_ty = iterable_info.item_ty.clone();
+            let deref = self.for_binding_deref(&binding_ty, borrows_iterable, &iterable_info);
             self.scopes.declare(Variable {
                 ident: Ident::new("it"),
                 modifier: DeclModifier::Let,
-                ty: elem_ty.clone(),
-                ownership: element_ownership,
+                ty: binding_ty,
+                ownership: for_binding_ownership(deref),
             });
-            vec![]
+            vec![HirForBinding {
+                ident: Ident::new("it"),
+                deref,
+            }]
         } else {
             body.parameters
                 .iter()
-                .map(|parameter| {
+                .enumerate()
+                .map(|(index, parameter)| {
+                    let binding_ty = for_parameter_type(
+                        parameter,
+                        iterable_info
+                            .binding_tys
+                            .get(index)
+                            .unwrap_or(&iterable_info.item_ty),
+                    );
+                    let deref =
+                        self.for_binding_deref(&binding_ty, borrows_iterable, &iterable_info);
                     self.scopes.declare(Variable {
                         ident: parameter.ident.clone(),
                         modifier: DeclModifier::Let,
-                        ty: elem_ty.clone(),
-                        ownership: element_ownership,
+                        ty: binding_ty,
+                        ownership: for_binding_ownership(deref),
                     });
-                    parameter.ident.clone()
+                    HirForBinding {
+                        ident: parameter.ident.clone(),
+                        deref,
+                    }
                 })
                 .collect()
         };
@@ -1660,7 +1677,7 @@ impl Checker<'_> {
         HirExpression::new(
             HirExpressionKind::For(Box::new(HirFor {
                 bindings,
-                bind_by_ref,
+                iterable_kind: iterable_info.kind,
                 iterable,
                 body: block,
                 collect,
@@ -1669,6 +1686,55 @@ impl Checker<'_> {
             Ownership::UniqueOwned,
             span,
         )
+    }
+
+    fn for_iterable_info(&mut self, iterable_ty: &TypeElement) -> ForIterableInfo {
+        match iterable_ty {
+            TypeElement::Array(array) => ForIterableInfo::single(array.elements.clone()),
+            TypeElement::Set(set) => ForIterableInfo::single(set.elements.clone()),
+            TypeElement::Dictionary(dict) => ForIterableInfo::key_value(
+                dict.key.clone(),
+                dict.value.clone(),
+                HirForIterableKind::Normal,
+            ),
+            TypeElement::OrderedDictionary(dict) => ForIterableInfo::key_value(
+                dict.key.clone(),
+                dict.value.clone(),
+                HirForIterableKind::Normal,
+            ),
+            TypeElement::Optional(optional) => ForIterableInfo::single(optional.inner.clone()),
+            TypeElement::Result(result) => ForIterableInfo::single(result.success.clone()),
+            TypeElement::Tuple(tuple) => {
+                let item_ty = unify_tuple_iteration_type(&tuple.elements, &mut self.errors);
+                ForIterableInfo {
+                    item_ty: item_ty.clone(),
+                    binding_tys: vec![item_ty],
+                    kind: HirForIterableKind::Tuple {
+                        len: tuple.elements.len(),
+                    },
+                }
+            }
+            TypeElement::Infer(_) | TypeElement::Void(_) => {
+                ForIterableInfo::single(TypeElement::infer())
+            }
+            _ => {
+                self.errors
+                    .warning("For loop on type that is not an iterator".to_string(), None);
+                ForIterableInfo::single(TypeElement::infer())
+            }
+        }
+    }
+
+    fn for_binding_deref(
+        &self,
+        binding_ty: &TypeElement,
+        borrows_iterable: bool,
+        iterable_info: &ForIterableInfo,
+    ) -> bool {
+        borrows_iterable
+            && iterable_info.kind == HirForIterableKind::Normal
+            && self.is_copy(binding_ty)
+            && !binding_ty.is_infer()
     }
 
     fn lower_assert(&mut self, call: &FunctionCall, span: Span) -> HirExpression {
@@ -2646,6 +2712,50 @@ fn closure_argument(argument: &FunctionCallArg) -> Option<&Closure> {
     }
 }
 
+fn try_ok_parameters(body: &Closure, ok_ty: &TypeElement) -> Vec<(Ident, TypeElement)> {
+    if body.parameters.is_empty() {
+        return vec![(Ident::new("it"), ok_ty.clone())];
+    }
+
+    body.parameters
+        .iter()
+        .map(|parameter| {
+            (
+                parameter.ident.clone(),
+                for_parameter_type(parameter, ok_ty),
+            )
+        })
+        .collect()
+}
+
+fn try_err_parameter(
+    else_expression: &ElseExpression,
+    err_ty: Option<&TypeElement>,
+) -> Option<(Ident, TypeElement)> {
+    match (else_expression.parameters.first(), err_ty) {
+        (Some(parameter), Some(err_ty)) => Some((
+            parameter.ident.clone(),
+            for_parameter_type(parameter, err_ty),
+        )),
+        (None, Some(err_ty)) => Some((Ident::new("it"), err_ty.clone())),
+        _ => None,
+    }
+}
+
+fn else_unwrap_err_parameter(
+    else_expression: &ElseExpression,
+    err_ty: Option<&TypeElement>,
+) -> Option<(Ident, TypeElement)> {
+    match (else_expression.parameters.first(), err_ty) {
+        (Some(parameter), Some(err_ty)) => Some((
+            parameter.ident.clone(),
+            for_parameter_type(parameter, err_ty),
+        )),
+        (None, Some(err_ty)) => Some((Ident::new("it"), err_ty.clone())),
+        _ => None,
+    }
+}
+
 fn argument_labels(arguments: &[FunctionCallArg]) -> Vec<Ident> {
     arguments
         .iter()
@@ -2684,6 +2794,75 @@ fn iteration_type(_fn_return: &TypeElement, expected: &TypeElement) -> TypeEleme
         TypeElement::Void(_) => TypeElement::void(),
         _ => TypeElement::infer(),
     }
+}
+
+struct ForIterableInfo {
+    item_ty: TypeElement,
+    binding_tys: Vec<TypeElement>,
+    kind: HirForIterableKind,
+}
+
+impl ForIterableInfo {
+    fn single(item_ty: TypeElement) -> Self {
+        Self {
+            item_ty: item_ty.clone(),
+            binding_tys: vec![item_ty],
+            kind: HirForIterableKind::Normal,
+        }
+    }
+
+    fn key_value(key: TypeElement, value: TypeElement, kind: HirForIterableKind) -> Self {
+        let item_ty = TypeElement::Tuple(Box::new(galvan_ast::TupleTypeItem {
+            elements: vec![key.clone(), value.clone()],
+            span: Span::default(),
+        }));
+
+        Self {
+            item_ty,
+            binding_tys: vec![key, value],
+            kind,
+        }
+    }
+}
+
+fn for_parameter_type(parameter: &ClosureParameter, inferred: &TypeElement) -> TypeElement {
+    if parameter.ty.is_infer() {
+        inferred.clone()
+    } else {
+        parameter.ty.clone()
+    }
+}
+
+fn for_binding_ownership(deref: bool) -> Ownership {
+    if deref {
+        Ownership::UniqueOwned
+    } else {
+        Ownership::Borrowed
+    }
+}
+
+fn unify_tuple_iteration_type(
+    elements: &[TypeElement],
+    errors: &mut ErrorCollector,
+) -> TypeElement {
+    let mut unified = None;
+    for element in elements {
+        unified = match unified {
+            None => Some(element.clone()),
+            Some(current) => unify_types(&current, element).or_else(|| {
+                errors.warning(
+                    format!(
+                        "Tuple iteration requires compatible element types, found {} and {}",
+                        current, element
+                    ),
+                    None,
+                );
+                Some(TypeElement::infer())
+            }),
+        };
+    }
+
+    unified.unwrap_or_else(TypeElement::infer)
 }
 
 /// Infer the most appropriate type for a number literal

--- a/galvan-hir/src/typecheck/tests.rs
+++ b/galvan-hir/src/typecheck/tests.rs
@@ -157,8 +157,9 @@ fn for_loops_reify_into_hir_nodes() {
     let HirExpressionKind::For(for_expr) = &tail.kind else {
         panic!("expected for expression");
     };
-    // Copy elements are destructured by reference
-    assert!(for_expr.bind_by_ref);
+    // Copy elements from borrowed iterables are destructured by reference.
+    assert_eq!(for_expr.bindings.len(), 1);
+    assert!(for_expr.bindings[0].deref);
     assert!(for_expr.collect.is_some());
     // The borrowed parameter is iterated without further adjustment
     assert!(for_expr.iterable.adjustments.is_empty());

--- a/galvan-into-ast/src/items/expression/postfix.rs
+++ b/galvan-into-ast/src/items/expression/postfix.rs
@@ -74,11 +74,24 @@ impl ReadCursor for ElseExpression {
         }
 
         cursor.next();
-        let body = Body::read_cursor(cursor, source)?;
-        let body_span = body.span;
-        let block = Block {
-            body,
-            span: body_span,
+        let block = match cursor.kind()? {
+            "body" => {
+                let body = Body::read_cursor(cursor, source)?;
+                let span = body.span;
+                Block { body, span }
+            }
+            "expression" => {
+                let expression = Expression::read_cursor(cursor, source)?;
+                let span = expression.span;
+                Block {
+                    body: Body {
+                        statements: vec![expression.into()],
+                        span,
+                    },
+                    span,
+                }
+            }
+            unknown => unreachable!("Expected else body or expression, got: {unknown}"),
         };
 
         cursor.goto_parent();

--- a/galvan-test/src/control_flow.galvan
+++ b/galvan-test/src/control_flow.galvan
@@ -23,6 +23,18 @@ test "If-Else expression" {
     assert result == "Wrong"
 }
 
+test "Nested else-if expression" {
+    let result = if false {
+        "wrong"
+    } else if true {
+        "correct"
+    } else {
+        "also wrong"
+    }
+
+    assert result == "correct"
+}
+
 test "Try expression" {
     let optional = if true { 6 }
 
@@ -33,6 +45,35 @@ test "Try expression" {
     }
 
     assert result == 7
+}
+
+test "Try expression with implicit it" {
+    let optional = if true { 6 }
+    let optional_result = try optional {
+        it + 1
+    } else {
+        0
+    }
+
+    assert optional_result == 7
+
+    let ok = returns_result(true)
+    let ok_result = try ok {
+        it + 1
+    } else {
+        it
+    }
+
+    assert ok_result == 43
+
+    let err = returns_result(false)
+    let err_result = try err {
+        it
+    } else {
+        it + 1
+    }
+
+    assert err_result == 22
 }
 
 test "Try expression does not own the value" {
@@ -92,6 +133,20 @@ fn double_or_minus_one(maybe: Int?) -> Int {
 test "Return from else on optional" {
     let result = double_or_minus_one(none)
     assert result == -1
+}
+
+fn result_or_fallback(ok: Bool) -> Int {
+    returns_result(ok) else { 99 }
+}
+
+fn result_or_error_plus_one(ok: Bool) -> Int {
+    returns_result(ok) else |err| { err + 1 }
+}
+
+test "Else unwrap on result" {
+    assert result_or_fallback(true) == 42
+    assert result_or_fallback(false) == 99
+    assert result_or_error_plus_one(false) == 22
 }
 
 test "Safe-call -> else on struct member" {

--- a/galvan-test/src/for.galvan
+++ b/galvan-test/src/for.galvan
@@ -87,3 +87,33 @@ test "implicit it parameter works" {
     
     assert sum == 6
 }
+
+test "for loop on optional and result" {
+    let maybe: Int? = 3
+    let nothing: Int? = none
+    let ok: Int!Int = 5
+    let err: Int!Int = throw_in_for_test()
+    mut sum = 0
+
+    for maybe {
+        sum += it
+    }
+
+    for nothing {
+        sum += 100
+    }
+
+    for ok {
+        sum += it
+    }
+
+    for err {
+        sum += 100
+    }
+
+    assert sum == 8
+}
+
+fn throw_in_for_test() -> Int!Int {
+    throw 4
+}

--- a/galvan-test/src/map.galvan
+++ b/galvan-test/src/map.galvan
@@ -64,6 +64,22 @@ test "Map with type annotation" {
     assert map["brussel sprouts"] == 14
 }
 
+test "For loop on map" {
+    let map: {String: Int} = {
+        "oranges": 4,
+        "apples": 5,
+        "brussel sprouts": 14,
+    }
+    mut total = 0
+
+    for map |fruit, count| {
+        assert fruit.len() > 0
+        total += count
+    }
+
+    assert total == 23
+}
+
 test "Access ordered map" {
     let map = [
         "oranges": 4,
@@ -74,6 +90,22 @@ test "Access ordered map" {
     assert map["oranges"] == 4
     assert map["apples"] == 5
     assert map["brussel sprouts"] == 14
+}
+
+test "For loop on ordered map" {
+    let map: [String: Int] = [
+        "oranges": 4,
+        "apples": 5,
+        "brussel sprouts": 14,
+    ]
+    mut total = 0
+
+    for map |fruit, count| {
+        assert fruit.len() > 0
+        total += count
+    }
+
+    assert total == 23
 }
 
 test "Insert into ordered map" {

--- a/galvan-transpiler/src/codegen/expression.rs
+++ b/galvan-transpiler/src/codegen/expression.rs
@@ -71,19 +71,30 @@ impl Transpile for HirIf {
 
 impl Transpile for HirElseUnwrap {
     fn transpile(&self, ctx: &Context, errors: &mut ErrorCollector) -> String {
-        let pattern = if self.by_ref {
+        let value_pattern = if self.by_ref {
             "ref __value"
         } else {
             "__value"
         };
-        transpile!(
-            ctx,
-            errors,
-            "if let Some({pattern}) = {} {{ {} }} else {}",
-            self.receiver,
-            self.value,
-            self.else_block,
-        )
+        let receiver = self.receiver.transpile(ctx, errors);
+        let value = self.value.transpile(ctx, errors);
+        let else_block = self.else_block.transpile(ctx, errors);
+
+        match self.kind {
+            HirElseUnwrapKind::Optional => {
+                format!("if let Some({value_pattern}) = {receiver} {{ {value} }} else {else_block}")
+            }
+            HirElseUnwrapKind::Result => {
+                let err_binding = self
+                    .err_binding
+                    .as_ref()
+                    .map(|binding| sanitize_name(binding.as_str()).into_owned())
+                    .unwrap_or_else(|| "_".into());
+                format!(
+                    "match {receiver} {{ Ok({value_pattern}) => {{ {value} }}, Err({err_binding}) => {else_block} }}"
+                )
+            }
+        }
     }
 }
 
@@ -127,19 +138,7 @@ impl Transpile for HirTry {
 impl Transpile for HirFor {
     fn transpile(&self, ctx: &Context, errors: &mut ErrorCollector) -> String {
         let iterable = self.iterable.transpile(ctx, errors);
-
-        let element = if self.bindings.is_empty() {
-            "it".to_string()
-        } else {
-            format!(
-                "({})",
-                self.bindings
-                    .iter()
-                    .map(|binding| sanitize_name(binding.as_str()))
-                    .join(", ")
-            )
-        };
-        let prefix = if self.bind_by_ref { "&" } else { "" };
+        let element = for_pattern(&self.bindings);
 
         let mut statements: Vec<String> = self
             .body
@@ -151,7 +150,12 @@ impl Transpile for HirFor {
         match &self.collect {
             None => {
                 let block = statements.join(";\n");
-                format!("for {prefix}{element} in {iterable} {{ {block}; }}")
+                render_for_loop(
+                    self.iterable_kind,
+                    iterable,
+                    element,
+                    format!("{{ {block}; }}"),
+                )
             }
             Some(elem_ty) => {
                 // Collect the value of each iteration into a result vector
@@ -160,15 +164,48 @@ impl Transpile for HirFor {
                 }
                 let block = statements.join(";\n");
                 let elem_ty = elem_ty.transpile(ctx, errors);
+                let loop_body = format!("{{ {block} }}");
+                let loop_expr = render_for_loop(self.iterable_kind, iterable, element, loop_body);
                 format!(
                     "{{
                 let mut __result: ::std::vec::Vec<{elem_ty}> = ::std::vec::Vec::new(); 
-                for {prefix}{element} in {iterable} {{ {block} }}
+                {loop_expr}
                 __result
             }}"
                 )
             }
         }
+    }
+}
+
+fn render_for_loop(
+    kind: HirForIterableKind,
+    iterable: String,
+    element: String,
+    body: String,
+) -> String {
+    match kind {
+        HirForIterableKind::Normal => format!("for {element} in {iterable} {body}"),
+        HirForIterableKind::Tuple { len } => {
+            let fields = (0..len).map(|i| format!("__iterable.{i}")).join(", ");
+            format!("{{ let __iterable = {iterable}; for {element} in [{fields}] {body} }}")
+        }
+    }
+}
+
+fn for_pattern(bindings: &[HirForBinding]) -> String {
+    let parts = bindings
+        .iter()
+        .map(|binding| {
+            let prefix = if binding.deref { "&" } else { "" };
+            format!("{prefix}{}", sanitize_name(binding.ident.as_str()))
+        })
+        .join(", ");
+
+    if bindings.len() <= 1 {
+        parts
+    } else {
+        format!("({parts})")
     }
 }
 

--- a/todo.md
+++ b/todo.md
@@ -36,8 +36,6 @@ commands remain subcommands.
 ## High Priority - Language Completeness
 
 - **Iteration** (galvan-hir/src/typecheck/expr.rs `lower_for`)
-  - For loop on dictionaries and ordered dictionaries
-  - For loop on optional and result types
   - Tuple iteration
 
 - **`ref` variables**


### PR DESCRIPTION
## Summary

This completes the control-flow gaps identified from the README for `for`, `try`, `if`, and `else`:

- parse and lower nested `else if` expressions
- materialize implicit `it` bindings for `try` success branches and `Result` error branches
- support `Result` values with `else`, including explicit `else |err|` fallback bindings
- support `for` loops over dictionaries, ordered dictionaries, optionals, and results
- track per-binding loop destructuring so map iteration can bind keys by reference while copying values when appropriate

The tree-sitter submodule is advanced to `b621057`, which adds the grammar support for `else` expression bodies and regenerates parser artifacts.

## Impact

Galvan programs can now use the README-documented control-flow forms that were previously missing or only partially lowered. The implementation keeps ownership decisions in HIR lowering and leaves codegen mechanical.

## Validation

- `cargo fmt --all`
- `cargo test --workspace`

Known existing warnings remain, including the generic-container warning from `galvan-test`.
