### PR TITLE
Clean up control flow implementation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,95 +1,168 @@
 # Galvan
+
 [![Tests](https://github.com/antoniusnaumann/galvan-lang/actions/workflows/tests.yaml/badge.svg)](https://github.com/antoniusnaumann/galvan-lang/actions/workflows/tests.yaml)
 [![Examples](https://github.com/antoniusnaumann/galvan-lang/actions/workflows/examples.yaml/badge.svg)](https://github.com/antoniusnaumann/galvan-lang/actions/workflows/examples.yaml)
 
-A high-level companion language for Rust.
+A high-level application language with concise syntax, value-oriented defaults,
+and explicit escape hatches when shared mutable state is needed.
 
 > [!IMPORTANT]
-> This is a work in progress and under development. It currently is in a state of a hobby project and most features described here are not yet implemented.
-> I am working on this project in my free time - if you like the ideas presented here, and want to help, feel free to contact me or start a discussion here on GitHub.
+> Galvan is a work in progress and still a hobby project. The core examples in
+> this README reflect implemented behavior unless a section has an explicit
+> implementation warning. If you like the ideas here and want to help, feel free
+> to contact me or start a discussion on GitHub.
 
-## Motiviation
-### What Galvan is not
-Galvan is not intended as a replacement for Rust. It is a companion language that transpiles to Rust.
-That means, Galvan's abstractions are not always zero-cost, instead Galvan tries to pick a sane default choice for most use cases.
+> [!NOTE]
+> Galvan is a companion language that transpiles to Rust. It is not intended to
+> replace Rust for low-level systems work; it is aimed at application code such
+> as CLI tools, services, and other high-level programs that still benefit from
+> the Rust ecosystem.
 
-Galvan is not intended for low-level programming - so you should not build a parser, compiler or audio compression library with it.
-Instead, Galvan is intended to be used for high-level applications, like CLI tools, web servers and so on. The ultimate goal is full Rust interoperability, so you can write your application in Galvan and rely on the full Rust ecosystem.
+## Motivation
 
-### Why Galvan?
-Rust is a great language, but it is not always the best choice for every task. Rust's syntax can be quite verbose and its type system and borrow checker - while extremely powerful - can be a burden for high-level applications and overwhelming for beginners.
-For low-level libraries and so-called "systems programming", Rust hits the sweet spot between helpful abstractions and being in control of implementation details. For application-level programming however, being provided with sensible choices for common use cases is important.
-This is where Galvan comes in: It provides a concise syntax and simplified way of writing Rust - without worrying about lifetimes, ownership and so on.
+Galvan focuses on the parts of day-to-day application programming where a
+language can provide strong defaults: concise declarations, ergonomic
+collections, predictable ownership behavior, and integrated tooling for tests
+and command-line interfaces.
 
-## A Tour of Galvan
-### Introduction to Galvan
+Galvan is not intended for low-level programming. You should not use it to write
+a parser, compiler, allocator, or audio compression library. It is designed for
+code where readability and fast iteration matter more than controlling every
+implementation detail.
 
-Galvan is a modern programming language that transpiles to Rust. It provides a concise syntax while leveraging the full power of Rust's ecosystem.
+> [!NOTE]
+> Rust is excellent when explicit control over memory, lifetimes, and low-level
+> performance is the central requirement. Galvan keeps Rust interoperability as a
+> goal while moving common application patterns into simpler syntax.
 
-### Basic Syntax and String Formatting
-Galvan programs use a regular `main` function.
+## A Tour Of Galvan
+
+### Programs And Strings
+
+Galvan programs use a regular `main` function:
+
 ```galvan
 fn main() {
     let name = "Galvan"
-    print("Welcome to \(name), the modern language!")
+    print("Welcome to \(name)!")
 }
 ```
-The main function can optionally receive the process argument vector. Like C's
-`argv`, the first element is the executable name.
+
+The main function can optionally receive the process argument vector. The first
+element is the executable name:
+
 ```galvan
 fn main(args: [String]) {
     print args
 }
 ```
-Note that Galvan strings always support inline format arguments.
 
+Strings support inline interpolation:
+
+```galvan
+let count = 3
+print("Packed \(count) orders")
+```
+
+Interpolation can contain member access and expressions. Strings also support
+escaped quotes, literal braces, and Unicode escapes:
+
+```galvan
+let dog = Dog(name: "Milo")
+
+print("Hi, \(dog.name)!")
+print("3 + 7 = \(3 + 7)")
+print("{\(3 + 7)}")
+print("\u{1F600}")
+```
+
+Character literals use single quotes and support common escape sequences:
+
+```galvan
+let first = 'a'
+let newline = '\n'
+let quote = '\''
+let greeting = "hello" ++ '!'
+```
 
 ### Functions
-Like in Rust, functions are defined with the `fn` keyword and return the value of the last expression:
+
+Functions are declared with `fn`. A function returns the value of its final
+expression unless it returns early:
+
 ```galvan
 fn add(a: Int, b: Int) -> Int {
     a + b
 }
 ```
 
-### Types 
-Types in Galvan are defined with the `type` keyword.
-```rust
-/// A struct definition
+### Types
+
+Types are declared with the `type` keyword:
+
+```galvan
 pub type Color {
     r: Int
     g: Int
     b: Int
 }
 
-// Structs can also use the named tuple syntax
 pub type Person(name: String, age: Int)
-
-/// A type alias
 pub type Human = Person
-
-/// A tuple type
 pub type Couple(Person, Person)
 ```
 
-Enums can have associated values, either for all variants or for specific variants. Enums are also declared using the `type` keyword:
-> [!WARNING]
-> Associated values for enums are not implemented yet
-```rust
-/// An enum type
-/// Enums can have general fields that are accessible to all enum variants
+Enums use the same `type` keyword. Variants can have no values, tuple-like
+values, or named values:
+
+```galvan
 pub type Theme(name: String) {
     Plain
-    /// Like in Rust, enum variants can have associated values, either named or unnamed
     Monochrome(Color)
-    /// Unlike in Rust, '(' is also used for enum variants with named fields
     Dark(background: Color, foreground: Color)
     Light(background: Color, foreground: Color)
 }
 ```
 
+The `name` field in `Theme(name: String)` is common data shared by all variants.
+Variant-specific fields are declared on each case.
+
+Enum variants are constructed and referenced with `Type::Variant` syntax:
+
+```galvan
+pub type ColorChoice {
+    Transparent
+    Gray(U8)
+    Rgb(r: U8, g: U8, b: U8)
+}
+
+let transparent = ColorChoice::Transparent
+let gray = ColorChoice::Gray(128)
+let rgb = ColorChoice::Rgb(r: 100, g: 10, b: 150)
+```
+
+Struct fields can provide default values:
+
+```galvan
+type Book {
+    title: String = "Field Notes"
+    content: String = "No notes yet"
+}
+
+fn main() {
+    let book = Book()
+}
+```
+
+> [!NOTE]
+> When a type can be constructed without arguments, Galvan automatically emits a
+> Rust `Default` implementation for the generated type.
+
 ### Member Functions
-All functions are declared top-level. If their first parameter is named `self`, they can be called as member functions (methods):
+
+All functions are declared top-level. If the first parameter is named `self`,
+the function can be called as a member function:
+
 ```galvan
 pub type Dog { name: String }
 
@@ -98,357 +171,386 @@ fn bark(self: Dog) {
 }
 
 fn main() {
-    let dog = Dog(name: "Bello")
+    let dog = Dog(name: "Milo")
     dog.bark()
 }
 ```
 
 ### Namespaces
-All items inside the same crate are accessible unqualified and items are qualified on a per-crate basis. If you wish to use items from other crates unqualified, you can import them using `use mycrate`. To import only a specific item, use path syntax such as `use mycrate::myfoo`.
 
-> [!HINT]
-> Galvan's `use mycrate` is equivalent to `use mycrate::*` in Rust
+Items in the same crate are available unqualified. Items from other crates can
+be imported with `use mycrate`, or more narrowly with path syntax such as
+`use mycrate::my_item`.
 
-### Namespaced Methods
-Galvan allows you to add methods also to types you do not own. When used outside the crate, you must import the name space via `use` or use the qualified method call syntax, such as
+> [!NOTE]
+> `use mycrate` imports all public items from that crate, similar to
+> `use mycrate::*` in Rust.
+
+Galvan also allows methods to be added to types you do not own. Outside the
+defining crate, use either a namespace-qualified call or import the namespace:
 
 ```galvan
-fn foo() {
+fn score_book() {
     let book = Book()
     let score = book.reader::read_and_judge()
 }
 
-// or
 use reader
 
-fn foo() {
+fn score_book_after_import() {
     let book = Book()
     let score = book.read_and_judge()
 }
 ```
 
-If method names from two imported crates clash, the qualified syntax must be used
+If method names from two imported crates clash, use qualified syntax.
 
 ### Overloading
-Limited overloading is supported via named parameters.
+
+Limited overloading is supported through argument labels:
 
 ```galvan
-fn foo(bar: U8) {}
-fn foo(bar: U8, num baz: U8) {
-    assert bar == baz
-    foo(bar)
+fn pick(value: U8) -> U8 {
+    value
 }
-fn foo(bar: U8, num baz: U8, ~ msg: U8) {
-    assert bar == baz, msg
-    foo(bar)
+
+fn pick(value: U8, plus increment: U8) -> U8 {
+    value + increment
+}
+
+fn pick(value: U8, plus increment: U8, ~ fallback: U8) -> U8 {
+    value + increment + fallback
 }
 
 fn main() {
-    foo(5)
-    foo(6, num: 6)
-    foo(7, num: 8, msg: "They were not equal!")
+    assert pick(1) == 1
+    assert pick(2, plus: 3) == 5
+    assert pick(4, plus: 5, fallback: 6) == 15
 }
 ```
 
-The `~` signifies that the label should be the same as the parameter name.
+The `~` marker means the call label should be the same as the parameter name.
 
-> [!HINT]
-> In the generated Rust code this would become `foo`, `foo__num` and `foo__num__msg`. Galvan names forbid double _ to avoid nameclashes with generated names. 
+> [!NOTE]
+> Generated Rust function names are label-mangled, such as `pick`,
+> `pick__plus`, and `pick__plus__fallback`. Galvan names forbid double
+> underscores to avoid clashes with generated names.
 
-### Default Values
-Struct types in Galvan can allow ommitting certain attributes when created with the default initializer. To do so, 
-
-```galvan
-type Book {
-    title: String = "Lorem Ipsum"
-    content: String = "Lorem ipsum dolor sit amet..."
-}
-
-fn main() {
-    let book = Book()
-}
-```
-
-In case the type can be constructed without arguments, Rust's `Default` trait is automatically implemented.
+## Data And Ownership
 
 ### Collections
 
-Galvan features syntactic sugar for collection types:
-```galvan
-pub type IntArray = [Int] // This is a Vec
-pub type StringSet = {String} // This is a HashSet
-pub type MyDict = {String: Int} // This is a HashMap
-pub type OrderedDict = [String: Int] // This is an IndexMap
-```
-
-Ordered types use `[]`, unordered types use `{}`.
-
-### Optionals and Result Types
-Galvan provides concise syntax for optionals and result types:
-
-```rust
-type OptionalInt = Int?
-type FileOrErr = File!
-type FileOrIoErr = File!IoError
-```
-The error variant is specified after the `!` symbol. If it is not given, a flexible error type is used.
+Galvan has concise syntax for common collection types:
 
 ```galvan
-fn open_file(path: String) -> File! {
-    let file = File::open(path)!
-    let contents = file.read_to_string()?.find("foo")?.uppercase() else { "" }
-    
-    contents
+pub type IntArray = [Int]
+pub type StringSet = {String}
+pub type Inventory = {String: Int}
+pub type DailyMenu = [String: Int]
+```
+
+Ordered collection types use `[]`; unordered collection types use `{}`.
+
+> [!NOTE]
+> These collection forms map to common Rust collection types: arrays are backed
+> by `Vec`, sets by `HashSet`, dictionaries by `HashMap`, and ordered
+> dictionaries by `IndexMap`.
+
+### Pass-By-Value, `mut`, And `ref`
+
+Arguments are passed by value by default. If a function needs to mutate the
+caller-owned value, mark the parameter as `mut`:
+
+```galvan
+fn make_uppercase(mut name: String) {
+    name = name.to_uppercase()
 }
-```
-`!` operator unwraps the result and early returns if the result is an error. This is identical to the `?` operator in Rust.
 
-`?` is the safe call operator in Galvan. The subsequent expression is only evaluated if the result is not an error and not none.
-
-`else` can also be used as the null-coalescing operator (since you can use else after every expression that is an optional or a result type), you can use it to provide a default if the left-hand side expression is none. 
-
-### Union Types
-Galvan supports union types everywhere where a type identifier is expected:
-> [!WARNING]
-> Union types are not implemented yet
-```rust
-fn print_value(value: Int | String) {
-    print("Value: \(value)")
+fn shouted(name: String) -> String {
+    name.to_uppercase()
 }
 ```
 
-### Pass-by-Value and Pass-by-Reference
-#### mutable vs. immutable function parameters
-By default, arguments are passed by value. If the argument needs to be mutated, the `mut` keyword can be used to pass it by reference.
-```galvan
-fn add_one(mut value: Int) {
-    value += 1
-}
+When calling a function with a `mut` parameter, the caller must annotate the
+argument:
 
-// By default, Galvan uses pass-by-value
-fn incremented(value : Int) -> Int {
-    value + 1
-} 
-```
-
-Galvan's `mut value: T` would be equivalent to Rust's `value: &mut T`. Galvan does not have immutable references, as all values are copy-on-write, i.e, Galvan tries to use immutable references for immutable values but creates a copy when assigning to a mutable binding.
 ```galvan
-// No copy is happening here as the value is not mutated
-// Arguments are passed by value by default
-fn bark_at(self: Dog, other: Dog) {
-    print("\(self.name) barks at \(other.name)")
+fn main() {
+    mut name = "milo"
+    make_uppercase(mut name)
 }
 ```
 
+Argument modifiers can also be written in postfix form:
+
 ```galvan
-// A copy is happening here as the value is mutated
-fn shout_at(self: Dog, other: Dog) {
-    // Redeclaring is neccessary as value parameters cannot be mutated
-    mut other = other
-    // Copy is happening here
-    other.name = other.name.uppercase()
-    print("\(self.name) shouts at \(other.name)")
+fn main() {
+    mut name = "milo"
+    make_uppercase(name.mut)
 }
 ```
 
+The same explicit modifiers are required when the receiver of a member function
+is declared as `mut self` or `ref self`:
+
 ```galvan
-fn grow(mut self: Dog) {
-    // This mutates the original value as it is passed by reference
-    self.age += 1
+fn rename(mut self: Dog, name: String) {
+    self.name = name
+}
+
+fn replace(ref self: Dog, replacement: Dog) {
+    self = replacement
+}
+
+fn main() {
+    mut dog = Dog(name: "Milo")
+    dog.mut.rename("Scout")
+
+    ref shared_dog = Dog(name: "Rex")
+    shared_dog.ref.replace(Dog(name: "Lassie"))
 }
 ```
 
-#### Stored References
-References that are allowed to be stored in structs have to be declared as heap references. This is done by prefixing the declaration with `ref`:
+Stored references are declared with `ref`. They use reference semantics and can
+be shared through structs or variables:
+
 ```galvan
 pub type Person {
-    name: String,
-    age: Int,
-    // This is a heap reference
+    name: String
+    age: Int
     ref dog: Dog
 }
 
 fn main() {
-    // Note that constructors use '(' with named arguments
-    ref dog = Dog(name: "Bello", age: 5)
-    // The `dog` field now points to the same entity as the `dog` variable 
+    ref dog = Dog(name: "Milo", age: 5)
     let person = Person(name: "Jochen", age: 67, dog: ref dog)
+
     dog.age += 1
-    
+
     print(person.dog.age) // 6
     print(dog.age) // 6
 }
 ```
-Heap references use atomic reference counting to be auto-freed when no longer needed and are always mutable.
-In contrast to `let` and `mut` values, `ref` values are not copied on assignment but instead point to the original object--they follow *reference semantics*. For this reason, they are always mutable.
 
-#### Argument Modifiers
-When calling a function with `mut` or `ref` parameters, you have to annotate the argument respectively. This is not the case for the receiver of a member function.
+Passing a `ref` value into a `ref` parameter also requires an explicit call-site
+modifier:
 
 ```galvan
-fn make_uppercase(mut arg: String) {
-    // ...
-}
-
-fn store(ref arg: String) {
+fn store(ref value: String) {
     // ...
 }
 
 fn main() {
-    ref my_string = "This is a heap ref"
-    
-    // Argument must be annotated as mutable
-    make_uppercase(mut my_string)
-    // Argument must be annotated as ref
-    store(ref my_string)
+    ref label = "shared"
+    store(ref label)
+    store(label.ref)
 }
 ```
-By annotating the argument as `mut`, the caller acknowledges that the given argument might be mutated in-place when calling this function.
-Immutable variables or members of immutable struct instances (declared with `let`) cannot be passed as `mut`. 
 
-By annotating the argument as `ref`, the caller acknowledges that the function might store a mutable (heap) reference.
-Only variables and members declared as `ref` can be passed as `ref`
+> [!NOTE]
+> Galvan's `mut value: T` is generated as a mutable Rust reference. Galvan does
+> not expose immutable references directly; immutable values are treated with
+> copy-on-write-style defaults, while `ref` values use heap-backed reference
+> semantics.
 
-Ref variables can be assigned to each other by reference
+`ref` variables can also be reassigned by reference:
 
 ```galvan
 fn main() {
-    ref msg = "Hello World!"
-    ref say = ref msg // now say points to msg
+    ref message = "Hello"
+    ref alias = ref message
 
-    msg = "Hi!"
-    print msg // "Hi!"
-    print say // "Hi!"
+    message = "Hi"
+    print alias // "Hi"
 
-    ref bye = "Bye!"
-    say = ref bye
+    ref farewell = "Bye"
+    alias = ref farewell
 
-    print msg // "Hi!"
-    print say // "Bye!"
-    print bye // "Bye!"
-
-    // meanwhile, this assigns only by value
-    msg = bye
-    bye = "Goodbye!"
-    print msg // "Bye!"
-    print bye // "Goodbye!"
+    print message // "Hi"
+    print alias // "Bye"
 }
-    
 ```
 
-### Control Flow
-#### Loops
-Like in Rust, loops can yield a value:
-> [!WARNING]
-> Loops are not implemented yet
-```rust
-mut i = 0
-let j = loop {
-    if i == 15 {
-        return i
+## Optionals, Results, And Control Flow
+
+### Optionals And Results
+
+Galvan uses `?` for optional types and `!` for result types:
+
+```galvan
+type OptionalInt = Int?
+type FileOrFlexibleError = File!
+type FileOrIoError = File!IoError
+```
+
+The error type is written after `!`. If it is omitted, Galvan uses a flexible
+error type.
+
+The postfix `!` operator unwraps a result and returns early if it contains an
+error:
+
+```galvan
+fn read_title(path: String) -> String! {
+    let file = File::open(path)!
+    file.read_to_string()!
+}
+```
+
+> [!NOTE]
+> Galvan's postfix `!` operator corresponds to Rust's `?` operator for early
+> error return. Galvan uses `?` for safe calls instead.
+
+The safe-call operator `?.` continues only when the receiver is not `none` and
+not an error. `else` can provide a fallback for optionals and results:
+
+```galvan
+let displayed_name = maybe_user?.name else { "Anonymous" }
+let points = load_reward_points() else { 0 }
+```
+
+Values are automatically wrapped when an optional or result is expected:
+
+```galvan
+let selected_count: Int? = 5
+let loaded_count: Int!String = 7
+
+fn count_or_default(count: Int?) -> Int {
+    count else { 0 }
+}
+
+assert count_or_default(21) == 21
+```
+
+### If And Else
+
+`if` can be used as a statement or as an expression:
+
+```galvan
+let shipping_status = if paid {
+    "ready"
+} else if inventory_reserved {
+    "waiting for pickup"
+} else {
+    "blocked"
+}
+```
+
+An `if` expression without an `else` produces an optional value:
+
+```galvan
+let discount = if customer_is_member { 10 }
+```
+
+### Match
+
+`match` expressions can return branch values and destructure enum variants:
+
+```galvan
+fn classify_color(color: Color) -> String {
+    match color {
+        Transparent { "transparent" }
+        Gray(value) { "gray \(value)" }
+        Rgb(r: red, b: blue, g: _) { "rgb \(red) \(blue)" }
+        _ { "unknown" }
     }
-    i += 1
 }
-print(j) // 15
-print(i) // 15
 ```
 
-For loops are also supported:
-```rust
+### Try
+
+`try` unwraps an optional or result. The unwrapped value is available through
+`it`, or through an explicitly named binding:
+
+```galvan
+try load_reward_points() {
+    print("Loaded \(it) points")
+} else {
+    print("Could not load points: \(it)")
+}
+
+try maybe_user |user| {
+    print(user.name)
+} else {
+    print("No user selected")
+}
+```
+
+Like `if`, `try` can also be used without an `else` branch:
+
+```galvan
+try maybe_user |user| {
+    print(user.name)
+}
+
+let selected_name = try maybe_user |user| { user.name }
+```
+
+### For Loops
+
+For loops work over ranges, collections, optionals, and results:
+
+```galvan
 for 0..<n {
     print(it)
 }
-```
-The loop variable is available via the `it` keyword, but can also be named explicitly using closure parameter syntax:
-```rust
-for 0..<n |i| {
-    print(i)
+
+for 0..<n |index| {
+    print(index)
 }
 ```
 
-For loops can be used as expression, they collect their iteration results in a vec
+For loops can also be expressions. In expression position, they collect each
+iteration result into an array:
 
-```rust
-let double_even: [Int] = for 0..=n {
-    if it % 2 == 1 { continue } // filters uneven numbers
-    it * 2 // maps 'it' to 'it * 2' 
+```galvan
+let doubled_even: [Int] = for 0..=n {
+    if it % 2 == 1 { continue }
+    it * 2
 }
-
-// double_even == [0, 4, 8, 12, ..., n * 2]
-
-print(double_even[2]) // 8
 ```
 
-Note that ranges are declared using `..<` (exclusive upper bound) or `..=` (inclusive upper bound).
+Range bounds use `..<` for exclusive upper bounds and `..=` for inclusive upper
+bounds.
 
-#### If-Else
 > [!WARNING]
-> Nested if-else is not implemented yet
-```rust
-if condition {
-    print("Condition is true")
-} else if other_condition {
-    print("Other condition is true")
-} else {
-    print("No condition is true")
-}
-```
+> General `loop { ... }` expressions are not implemented yet. `for` loops are
+> implemented for arrays, sets, dictionaries, ordered dictionaries, optionals,
+> results, and ranges. Tuple iteration is still incomplete.
 
-#### Try
-You can use try to unwrap a result or optional:
-> [!WARNING]
-> Implicit arguments via `it` are not implemented yet
-```rust
-try potential_error {
-    print("Optional was \(it)")
-} else {
-    print("Error occured: \(it)")
-}
-```
-The unwrapped variant is available via the it keyword, like in closures. You can also name it using closure parameter syntax to declare them explicitly:
-```rust
-try potential_error |value| {
-    print("Optional was \(value)")
-} else |error| {
-    print("Error occured: \(error)")
-}
-```
-Like `if`, you can also use `try` without an else branch:
-```rust
-try potential_error |value| {
-    print("Optional was \(value)")
-}
+### Return And Throw
 
-let optional = try potential_error |successful| { successful }
-```
-This can be useful to pass the unwrapped value to a function, or to convert a Result to an Optional.
+Return values are implicit, but `return` can be used for early returns:
 
-#### Return and Throw
-Return values are implicit, however you can use the `return` keyword to return early:
-```rust 
+```galvan
 fn fib(n: Int) -> Int {
     if n <= 1 {
         return n
     }
+
     fib(n - 1) + fib(n - 2)
 }
 ```
 
-Returning an error early is done using the `throw` keyword:
-```rust
+Errors are returned early with `throw`:
+
+```galvan
 fn checked_divide(a: Float, b: Float) -> Float! {
     if b == 0 {
         throw "Division by zero"
     }
+
     a / b
 }
 ```
 
+## Abstraction Features
+
 ### Generics
-In Galvan, type identifiers always start with an upper case letter. Using a lower case letter instead introduces a type parameter:
-> [!WARNING]
-> Generics are not implemented yet
-```rust
+
+Type identifiers start with an uppercase letter. A lowercase type name
+introduces a type parameter:
+
+```galvan
 type Container {
     value: t
 }
@@ -458,18 +560,78 @@ fn get_value(self: Container<t>) -> t {
 }
 ```
 
-Bounds can be specified using the `where` keyword:
-```rust
-fn concat_hash(self: t, other: t) -> t where t: Hash {
-    self.hash() ++ other.hash()
+Bounds can be specified with `where`:
+
+```galvan
+fn concat_text(self: t, other: t) -> String where t: ToString {
+    self.to_string() ++ other.to_string()
 }
 ```
 
-### Operators
-#### Builtin Operators
-Galvan offers a wide range of builtin operators. While all of them have an ASCII variant, Galvan also accepts a unicode symbol where it makes sense.
+> [!WARNING]
+> Generic syntax, basic generic functions, methods, and `where` clauses are
+> implemented, but generic type inference and compatibility checking are still
+> incomplete. Some generic cases may produce warnings or fall back to broad
+> compatibility.
 
-Arithmetic operators: 
+### Closures
+
+Closures use parameter-list syntax:
+
+```galvan
+let add = |a, b| a + b
+```
+
+Closure types use the same `|_|` shape:
+
+```galvan
+fn map(self: [t], f: |t| u) -> [u] {
+    mut result = []
+    for self {
+        result.push(f(it))
+    }
+    result
+}
+```
+
+Functions with trailing closures can omit the regular argument parentheses:
+
+```galvan
+orders
+    .map |order| { order.total }
+    .filter |total| { total > 0 }
+    .fold 0 |acc, total| { acc + total }
+```
+
+> [!WARNING]
+> Numbered closure parameters such as `#0` and `#1` are planned but not
+> implemented yet.
+
+### Parentheses-Free Function Calls
+
+In a statement or on the right-hand side of an assignment, function-call
+parentheses can be omitted:
+
+```galvan
+fn add(a: Int, b: Int) -> Int {
+    a + b
+}
+
+fn main() {
+    let result = add 2, 3
+    print result
+}
+```
+
+This syntax is not allowed in function arguments, and calls with no arguments
+still require parentheses to avoid ambiguity with variables.
+
+## Operators
+
+### Builtin Operators
+
+Arithmetic operators:
+
 - `+`: Addition
 - `-`: Subtraction
 - `*`: Multiplication
@@ -477,36 +639,39 @@ Arithmetic operators:
 - `%`: Remainder
 - `^`: Exponentiation
 
-> [!NOTE] 
-> Galvan does not offer unicode alternatives for logical operators
-> as `∧` and `∨` could be confused with `v` and `^` respectively.
-> If you want to use unicode operators, you can define them yourself.
 Logical operators:
+
 - `and`, `&&`: Logical and
 - `or`, `||`: Logical or
 - `xor`: Logical xor
 - `not`, `!`: Logical not
 
+> [!NOTE]
+> Galvan does not provide Unicode alternatives for logical operators because
+> `∧` and `∨` can be confused with `v` and `^`. Custom operators can provide
+> those spellings later.
+
 Bitwise operators:
+
 - `|`: Bitwise or
 - `&`: Bitwise and
 - `~`: Bitwise xor
 - `<<`: Bitwise left shift
 - `>>`: Bitwise right shift
 
-Like in Lua, `^` is exponentiation and `~` is bitwise xor.
-
 Comparison operators:
+
 - `==`: Equality
 - `!=`, `≠`: Inequality
 - `<`: Less than
 - `<=`, `≤`: Less than or equal
-- `>` Greater than
-- `>=`, `≥`:: Greater than or equal
-- `===`, `≡`: Pointer equality, only works for heap references
-- `!==`, `≢`: Pointer inequality, only works for heap references
+- `>`: Greater than
+- `>=`, `≥`: Greater than or equal
+- `===`, `≡`: Pointer equality for heap references
+- `!==`, `≢`: Pointer inequality for heap references
 
 Collection operators:
+
 - `++`: Concatenation
 - `--`: Removal
 - `**`: Repetition
@@ -515,15 +680,20 @@ Collection operators:
 - `in`, `∈`, `∊`: Membership
 
 Range operators:
-- `..<`: Exclusive Range
-- `..=`: Inclusive Range
-- `+-`, `±`: Inclusive Range around a value (tolerance)
 
-#### Canonical Operator Implementation
+- `..<`: Exclusive range
+- `..=`: Inclusive range
+- `+-`, `±`: Inclusive range around a value
+
 > [!WARNING]
-> Canonical operator implementation is not implemented yet
+> Some listed operators are still incomplete. In particular, collection removal
+> (`--`), repetition (`**`), slicing (`[:]`), unary logical not, and custom
+> operators need additional implementation work.
 
-Galvan does not support operator overloading. Instead, operators are automatically implemented in a consistent fashion on types where all members individually implement that operator, e.g.:
+### Canonical Operator Implementation
+
+Galvan's intended operator model is structural: operators should be derived for
+types whose members support the same operation.
 
 ```galvan
 type Vec2 {
@@ -541,74 +711,43 @@ test "Automatically derive addition for struct" {
     assert result.y == this_vec.y + that_vec.y
 }
 ```
-### Closures
-Closures are defined using the parameter list syntax:
-```rust
-let add = |a, b| a + b
-```
 
-Closure types use the `|_|` syntax:
-```rust
-fn floatifier(self: [Int], f: |Int| Float) -> [Float] {
-    // ...
-}
+> [!WARNING]
+> Canonical operator implementation is not implemented yet.
 
-fn map(self: [t], f: |t| u) -> [u] {
-    mut result = []
-    for self {
-        result.push(f(it))
-    }
-    result
+### Union Types
+
+Galvan's intended union syntax uses `|` where a type identifier is expected:
+
+```galvan
+fn print_value(value: Int | String) {
+    print("Value: \(value)")
 }
 ```
 
-#### Trailing Closures
-Functions with trailing closures are allowed to omit the parameter list and the () around the parameter list:
-```rust
-iter
-    .map { it * 2 }
-    // Trailing closures with only one parameter can use the it keyword instead of naming it explicitly
-    .filter { it % 2 == 0 }
-    // The parameter list before the trailing closure can be omitted
-    .reduce start |acc, e| { acc + e }
-```
-
-Trailing closures can also use numbered parameters instead of giving a parameter list
-```rust
-iter
-    .map { #0 * 2 }
-    .filter { #0 % 2 == 0 }
-    .reduce start { #0 + #1 }
-```
-
-### Parentheses-Free Function Calls
-In a statement or as the right-hand side of an assignment, parentheses for function calls can be omitted:
-```rust
-fn add(a: Int, b: Int) -> Int {
-    a + b
-}
-
-fn main() {
-    let result = add 2, 3
-    print result // 5
-}
-```
-As this syntax is only allowed in assignments and statements, you cannot use it in i.e. function parameters. This avoids ambiguity.
-It is also not allowed to use this syntax for functions that take no arguments to avoid confusing it with a variable.
+> [!WARNING]
+> Union types are not implemented yet.
 
 ## Semicolon Inference
-While Galvan uses semicolons to separate statements, Galvan infers semicolons on newlines when:
-- the next line starts with an alpha-character (or an underscore) as the first non-whitespace character
-- the next line starts with `{`, `(`, `[`, or `'`, `"` as the first non-whitespace character
 
-Regardless of the rules above, Galvan does not infer a semicolon when the current line itself is not a valid statement.
-Galvan also infers commas for struct type declarations if a newline is used after each field instead.
+Galvan uses semicolons to separate statements, but infers semicolons on newlines
+when:
 
+- the next line starts with an alpha character or underscore as the first
+  non-whitespace character
+- the next line starts with `{`, `(`, `[`, `'`, or `"` as the first
+  non-whitespace character
 
-## Advanced Features
-Galvan is a "batteries-included" language. This means, it provides language-level support for popular Rust features and crates.
+Galvan does not infer a semicolon when the current line itself is not a valid
+statement. It also infers commas for struct type declarations when fields are
+separated by newlines.
+
+## Tooling-Oriented Features
+
 ### Testing
-Every obstacle to writing unit tests is a unit test that is not written. For this reason, Galvan provides a concise syntax to quickly write unit tests in any .galvan file:
+
+Galvan provides a concise syntax for unit tests in any `.galvan` file:
+
 ```galvan
 test {
     assert 2 == 2
@@ -618,14 +757,14 @@ test "Ensure that addition works correctly" {
     assert 2 + 2 == 4
 }
 ```
-Tests can take a string as a description. Although this is optional, adding a brief description to your unit tests is highly encouraged.
 
-### CLI argument parsing
-Galvan has built-in support for creating CLI apps with arguments and subcommands by integrating the popular *clap* crate.
-This code:
+Test descriptions are optional but encouraged.
+
+### CLI Argument Parsing
+
+Galvan has built-in support for CLI apps with arguments and subcommands:
 
 ```galvan
-// cmd main arguments are top-level flags rather than a subcommand
 cmd main(
     /// Optional name to greet when no subcommand is selected
     n name: String?
@@ -633,18 +772,14 @@ cmd main(
     try name |name| {
         print "Hello \(name)!"
     } else {
-        print "Hello World! ..."
+        print "Hello World!"
     }
 }
 
-// commands automatically get added to the CLI application as subcommands, including doc comments being shown in the -h argument
-// so this adds a <program-name> greet -n <NAME> -s <SURNAME> subcommand
 /// Greets the user
 cmd greet(
     /// First name of the person to greet
-    // args can specify both a short and a long name, here -n and --name
     n name: String,
-    // optional args can be left out
     /// Surname of the person that should be greeted
     s surname: String?
 ) {
@@ -656,8 +791,14 @@ cmd greet(
 }
 ```
 
-creates this CLI tool: 
-```
+> [!NOTE]
+> The CLI support is generated through the Rust `clap` crate. Top-level
+> `cmd main` arguments become top-level flags, and other `cmd` declarations
+> become subcommands.
+
+The generated CLI looks like this:
+
+```text
 $ my-app --help
 Commands:
   greet  Greets the user
@@ -667,11 +808,10 @@ Options:
   -h, --help     Print help
   -V, --version  Print version
 
-
 $ my-app greet --help
 Greets the user
 
-Usage: galvan-cli-hello-world greet [OPTIONS] --name <NAME>
+Usage: my-app greet [OPTIONS] --name <NAME>
 
 Options:
   -n, --name <NAME>        First name of the person to greet

--- a/galvan-hir/src/typecheck/expr.rs
+++ b/galvan-hir/src/typecheck/expr.rs
@@ -582,11 +582,7 @@ impl Checker<'_> {
             Some(DeclModifier::Ref) => HirExpression::error("invalid ref passing mode", span),
             Some(DeclModifier::Let) => unreachable!("let is not an argument passing modifier"),
             None => {
-                let ownership = if self.is_copy(&param.param_type) {
-                    Ownership::UniqueOwned
-                } else {
-                    Ownership::Borrowed
-                };
+                let ownership = value_argument_ownership(self.is_copy(&param.param_type));
                 let expected = Expected::with(param.param_type.clone(), ownership);
                 self.coerce(lowered, &expected)
             }
@@ -705,11 +701,7 @@ impl Checker<'_> {
                         unreachable!("let modifiers are rejected while merging")
                     }
                     None => {
-                        let ownership = if self.is_copy(param_ty) {
-                            Ownership::UniqueOwned
-                        } else {
-                            Ownership::Borrowed
-                        };
+                        let ownership = value_argument_ownership(self.is_copy(param_ty));
                         let expected = Expected::with(param_ty.clone(), ownership);
                         self.coerce(lowered, &expected)
                     }
@@ -1034,19 +1026,10 @@ impl Checker<'_> {
     ) -> (HirMatchBindingPattern, Option<Variable>) {
         match binding {
             MatchBindingPattern::Ident(ident) => {
-                let ownership = if self.is_copy(ty) || ty.is_infer() {
-                    Ownership::UniqueOwned
-                } else {
-                    Ownership::SharedOwned
-                };
+                let ownership = match_binding_ownership(self.is_copy(ty), ty.is_infer());
                 (
                     HirMatchBindingPattern::Binding(ident.clone()),
-                    Some(Variable {
-                        ident: ident.clone(),
-                        modifier: DeclModifier::Let,
-                        ty: ty.clone(),
-                        ownership,
-                    }),
+                    Some(let_variable(ident.clone(), ty.clone(), ownership)),
                 )
             }
             MatchBindingPattern::Wildcard(_) => (HirMatchBindingPattern::Wildcard, None),
@@ -1224,12 +1207,11 @@ impl Checker<'_> {
         };
 
         self.scopes.push();
-        self.scopes.declare(Variable {
-            ident: Ident::new("__value"),
-            modifier: DeclModifier::Let,
-            ty: inner_ty.clone(),
-            ownership: value_ownership,
-        });
+        self.scopes.declare(let_variable(
+            Ident::new("__value"),
+            inner_ty.clone(),
+            value_ownership,
+        ));
         let value = HirExpression::new(
             HirExpressionKind::Variable(Ident::new("__value")),
             inner_ty.clone(),
@@ -1240,18 +1222,11 @@ impl Checker<'_> {
         self.scopes.pop();
 
         self.scopes.push();
-        let err_binding = else_unwrap_err_parameter(else_expression, err_ty.as_ref());
+        let err_binding = fallback_parameter(else_expression, err_ty.as_ref());
         if let Some((ident, ty)) = &err_binding {
-            self.scopes.declare(Variable {
-                ident: ident.clone(),
-                modifier: DeclModifier::Let,
-                ty: ty.clone(),
-                ownership: if self.is_copy(ty) {
-                    Ownership::UniqueOwned
-                } else {
-                    Ownership::Borrowed
-                },
-            });
+            let ownership = value_argument_ownership(self.is_copy(ty));
+            self.scopes
+                .declare(let_variable(ident.clone(), ty.clone(), ownership));
         }
         let else_block = self.lower_block(&else_expression.block.body, &value_expected);
         self.scopes.pop();
@@ -1445,12 +1420,8 @@ impl Checker<'_> {
                 let ok_bindings = ok_parameters
                     .into_iter()
                     .map(|(ident, ty)| {
-                        self.scopes.declare(Variable {
-                            ident: ident.clone(),
-                            modifier: DeclModifier::Let,
-                            ty,
-                            ownership: Ownership::Borrowed,
-                        });
+                        self.scopes
+                            .declare(let_variable(ident.clone(), ty, Ownership::Borrowed));
                         ident
                     })
                     .collect();
@@ -1507,33 +1478,16 @@ impl Checker<'_> {
             expected.clone()
         };
 
-        let binding_ownership = |checker: &Self, ty: &TypeElement, scrutinee: Ownership| {
-            // `Infer` is assumed to be copy here, matching the unwrap of
-            // optionals with unknown inner type
-            if checker.is_copy(ty) || ty.is_infer() {
-                Ownership::UniqueOwned
-            } else {
-                match scrutinee {
-                    Ownership::UniqueOwned | Ownership::SharedOwned => Ownership::SharedOwned,
-                    _ => Ownership::Borrowed,
-                }
-            }
-        };
-
         let scrutinee_ownership = condition.adjusted_ownership();
 
         self.scopes.push();
-        let ok_ownership = binding_ownership(self, &ok_ty, scrutinee_ownership);
+        let ok_ownership = self.unwrap_binding_ownership(&ok_ty, scrutinee_ownership);
         let ok_parameters = try_ok_parameters(body, &ok_ty);
         let ok_bindings: Vec<Ident> = ok_parameters
             .into_iter()
             .map(|(ident, ty)| {
-                self.scopes.declare(Variable {
-                    ident: ident.clone(),
-                    modifier: DeclModifier::Let,
-                    ty,
-                    ownership: ok_ownership,
-                });
+                self.scopes
+                    .declare(let_variable(ident.clone(), ty, ok_ownership));
                 ident
             })
             .collect();
@@ -1541,16 +1495,13 @@ impl Checker<'_> {
         self.scopes.pop();
 
         self.scopes.push();
-        let err_binding = try_err_parameter(else_expression, err_ty.as_ref()).map(|(ident, ty)| {
-            let err_ownership = binding_ownership(self, &ty, scrutinee_ownership);
-            self.scopes.declare(Variable {
-                ident: ident.clone(),
-                modifier: DeclModifier::Let,
-                ty,
-                ownership: err_ownership,
+        let err_binding =
+            fallback_parameter(else_expression, err_ty.as_ref()).map(|(ident, ty)| {
+                let err_ownership = self.unwrap_binding_ownership(&ty, scrutinee_ownership);
+                self.scopes
+                    .declare(let_variable(ident.clone(), ty, err_ownership));
+                ident
             });
-            ident
-        });
         let else_block = self.lower_block(&else_expression.block.body, &branch_expected);
         self.scopes.pop();
 
@@ -1619,18 +1570,12 @@ impl Checker<'_> {
         self.scopes.push();
         let bindings: Vec<HirForBinding> = if body.parameters.is_empty() {
             // Implicit `it` parameter
-            let binding_ty = iterable_info.item_ty.clone();
-            let deref = self.for_binding_deref(&binding_ty, borrows_iterable, &iterable_info);
-            self.scopes.declare(Variable {
-                ident: Ident::new("it"),
-                modifier: DeclModifier::Let,
-                ty: binding_ty,
-                ownership: for_binding_ownership(deref),
-            });
-            vec![HirForBinding {
-                ident: Ident::new("it"),
-                deref,
-            }]
+            vec![self.lower_for_binding(
+                Ident::new("it"),
+                iterable_info.item_ty.clone(),
+                borrows_iterable,
+                &iterable_info,
+            )]
         } else {
             body.parameters
                 .iter()
@@ -1643,18 +1588,12 @@ impl Checker<'_> {
                             .get(index)
                             .unwrap_or(&iterable_info.item_ty),
                     );
-                    let deref =
-                        self.for_binding_deref(&binding_ty, borrows_iterable, &iterable_info);
-                    self.scopes.declare(Variable {
-                        ident: parameter.ident.clone(),
-                        modifier: DeclModifier::Let,
-                        ty: binding_ty,
-                        ownership: for_binding_ownership(deref),
-                    });
-                    HirForBinding {
-                        ident: parameter.ident.clone(),
-                        deref,
-                    }
+                    self.lower_for_binding(
+                        parameter.ident.clone(),
+                        binding_ty,
+                        borrows_iterable,
+                        &iterable_info,
+                    )
                 })
                 .collect()
         };
@@ -1735,6 +1674,40 @@ impl Checker<'_> {
             && iterable_info.kind == HirForIterableKind::Normal
             && self.is_copy(binding_ty)
             && !binding_ty.is_infer()
+    }
+
+    fn lower_for_binding(
+        &mut self,
+        ident: Ident,
+        binding_ty: TypeElement,
+        borrows_iterable: bool,
+        iterable_info: &ForIterableInfo,
+    ) -> HirForBinding {
+        let deref = self.for_binding_deref(&binding_ty, borrows_iterable, iterable_info);
+        self.scopes.declare(let_variable(
+            ident.clone(),
+            binding_ty,
+            for_binding_ownership(deref),
+        ));
+
+        HirForBinding { ident, deref }
+    }
+
+    fn unwrap_binding_ownership(
+        &self,
+        ty: &TypeElement,
+        scrutinee_ownership: Ownership,
+    ) -> Ownership {
+        // `Infer` is assumed to be copy here, matching optional/result unwraps
+        // with unknown inner types.
+        if self.is_copy(ty) || ty.is_infer() {
+            return Ownership::UniqueOwned;
+        }
+
+        match scrutinee_ownership {
+            Ownership::UniqueOwned | Ownership::SharedOwned => Ownership::SharedOwned,
+            _ => Ownership::Borrowed,
+        }
     }
 
     fn lower_assert(&mut self, call: &FunctionCall, span: Span) -> HirExpression {
@@ -2728,7 +2701,7 @@ fn try_ok_parameters(body: &Closure, ok_ty: &TypeElement) -> Vec<(Ident, TypeEle
         .collect()
 }
 
-fn try_err_parameter(
+fn fallback_parameter(
     else_expression: &ElseExpression,
     err_ty: Option<&TypeElement>,
 ) -> Option<(Ident, TypeElement)> {
@@ -2742,17 +2715,28 @@ fn try_err_parameter(
     }
 }
 
-fn else_unwrap_err_parameter(
-    else_expression: &ElseExpression,
-    err_ty: Option<&TypeElement>,
-) -> Option<(Ident, TypeElement)> {
-    match (else_expression.parameters.first(), err_ty) {
-        (Some(parameter), Some(err_ty)) => Some((
-            parameter.ident.clone(),
-            for_parameter_type(parameter, err_ty),
-        )),
-        (None, Some(err_ty)) => Some((Ident::new("it"), err_ty.clone())),
-        _ => None,
+fn let_variable(ident: Ident, ty: TypeElement, ownership: Ownership) -> Variable {
+    Variable {
+        ident,
+        modifier: DeclModifier::Let,
+        ty,
+        ownership,
+    }
+}
+
+fn value_argument_ownership(is_copy: bool) -> Ownership {
+    if is_copy {
+        Ownership::UniqueOwned
+    } else {
+        Ownership::Borrowed
+    }
+}
+
+fn match_binding_ownership(is_copy: bool, is_infer: bool) -> Ownership {
+    if is_copy || is_infer {
+        Ownership::UniqueOwned
+    } else {
+        Ownership::SharedOwned
     }
 }
 

--- a/galvan-into-ast/src/cursor_macro.rs
+++ b/galvan-into-ast/src/cursor_macro.rs
@@ -1,5 +1,3 @@
-use galvan_parse::{Node, ParseError, TreeCursor};
-
 #[macro_export]
 macro_rules! cursor_expect {
     ($cursor:ident, $rule:literal) => {{

--- a/galvan-into-ast/src/items/expression/function_call.rs
+++ b/galvan-into-ast/src/items/expression/function_call.rs
@@ -382,7 +382,6 @@ impl ReadCursor for EnumConstructorArg {
             _ => {
                 // Look for the pattern: if we have ident followed by colon, it's a named field
                 if first_kind == "ident" {
-                    let current_position = cursor.node();
                     let ident = Ident::read_cursor(cursor, source)?;
                     cursor.next();
 

--- a/galvan-resolver/src/scope.rs
+++ b/galvan-resolver/src/scope.rs
@@ -1,8 +1,10 @@
-use crate::{FunctionId, Lookup, LookupContext};
+use std::collections::HashMap;
+
 use galvan_ast::{
     DeclModifier, FnDecl, Ident, Ownership, ToplevelItem, TypeDecl, TypeElement, TypeIdent,
 };
-use std::collections::HashMap;
+
+use crate::{FunctionId, Lookup, LookupContext};
 
 #[derive(Debug, Default)]
 pub struct Scope<'a> {
@@ -18,7 +20,7 @@ pub struct Scope<'a> {
 }
 
 impl Scope<'_> {
-    pub fn child(parent: &Self) -> Scope {
+    pub fn child(parent: &Self) -> Scope<'_> {
         Scope {
             parent: Some(parent),
             variables: HashMap::new(),

--- a/galvan-test/src/collections.galvan
+++ b/galvan-test/src/collections.galvan
@@ -1,22 +1,22 @@
 test "Collect iter into vector" {
-    let v = [1, 2, 3, 4, 5, 6, 7, 8]
-    let v = v
+    let order_quantities = [1, 2, 3, 4, 5, 6, 7, 8]
+    let packed_quantities = order_quantities
         .iter()
         .copied()
-        .map(|x| x * 2)
-        .filter(|x| x % 4 == 0)
+        .map(|quantity| quantity * 2)
+        .filter(|quantity| quantity % 4 == 0)
         .vec()
 
-    assert v == [4, 8, 12, 16]
+    assert packed_quantities == [4, 8, 12, 16]
 }
 
 test "Call functions on collection literal" {
-    let v = [1, 2, 3, 4, 5, 6, 7, 8]
+    let packed_quantities = [1, 2, 3, 4, 5, 6, 7, 8]
         .iter()
         .copied()
-        .map(|x| x * 2)
-        .filter(|x| x % 4 == 0)
+        .map(|quantity| quantity * 2)
+        .filter(|quantity| quantity % 4 == 0)
         .vec()
 
-    assert v == [4, 8, 12, 16]
+    assert packed_quantities == [4, 8, 12, 16]
 }

--- a/galvan-test/src/control_flow.galvan
+++ b/galvan-test/src/control_flow.galvan
@@ -9,13 +9,11 @@ test "If clause" {
 test "If expression" {
     let available_label = if 6 == 6 { "in stock" }
 
-    // TODO: Auto-unwrap optionals in comparisons to make this work
-    // assert available_label == "in stock"
+    assert available_label == "in stock"
 
     let unavailable_label = if 6 == 7 { "in stock" }
 
-    // TODO: Introduce none keyword
-    // assert unavailable_label == none
+    assert unavailable_label == none
 }
 
 test "If-Else expression" {

--- a/galvan-test/src/control_flow.galvan
+++ b/galvan-test/src/control_flow.galvan
@@ -7,102 +7,102 @@ test "If clause" {
 }
 
 test "If expression" {
-    let some = if 6 == 6 { "Something" }
+    let available_label = if 6 == 6 { "in stock" }
 
     // TODO: Auto-unwrap optionals in comparisons to make this work
-    // assert some == "Something"
+    // assert available_label == "in stock"
 
-    let nothing = if 6 == 7 { "Something" }
+    let unavailable_label = if 6 == 7 { "in stock" }
 
     // TODO: Introduce none keyword
-    // assert nothing == none
+    // assert unavailable_label == none
 }
 
 test "If-Else expression" {
-    let result = if 6 == 7 { "Correct" } else { "Wrong" }
-    assert result == "Wrong"
+    let shipping_status = if 6 == 7 { "ready" } else { "delayed" }
+    assert shipping_status == "delayed"
 }
 
 test "Nested else-if expression" {
-    let result = if false {
-        "wrong"
+    let weather_alert = if false {
+        "storm warning"
     } else if true {
-        "correct"
+        "rain advisory"
     } else {
-        "also wrong"
+        "clear skies"
     }
 
-    assert result == "correct"
+    assert weather_alert == "rain advisory"
 }
 
 test "Try expression" {
-    let optional = if true { 6 }
+    let seats_available = if true { 6 }
 
-    let result = try optional |value| {
-        value + 1
+    let seats_after_booking = try seats_available |seats| {
+        seats + 1
     } else {
-        panic "Optional was none"
+        panic "Expected seat count"
     }
 
-    assert result == 7
+    assert seats_after_booking == 7
 }
 
 test "Try expression with implicit it" {
-    let optional = if true { 6 }
-    let optional_result = try optional {
+    let seats_available = if true { 6 }
+    let seats_after_booking = try seats_available {
         it + 1
     } else {
         0
     }
 
-    assert optional_result == 7
+    assert seats_after_booking == 7
 
-    let ok = returns_result(true)
-    let ok_result = try ok {
+    let loaded_points = load_reward_points(true)
+    let updated_points = try loaded_points {
         it + 1
     } else {
         it
     }
 
-    assert ok_result == 43
+    assert updated_points == 43
 
-    let err = returns_result(false)
-    let err_result = try err {
+    let failed_load = load_reward_points(false)
+    let retry_score = try failed_load {
         it
     } else {
         it + 1
     }
 
-    assert err_result == 22
+    assert retry_score == 22
 }
 
 test "Try expression does not own the value" {
-    let dog: Dog? = Dog(name: "Bello", age: 4)
-    try dog |bello| { assert bello.age == 4 } else { panic "Expected that dog is some" }
-    try dog |bello| { assert bello.name == "Bello" } else { panic "Expected that dog is some" }
+    let adopted_dog: Dog? = Dog(name: "Milo", age: 4)
+    try adopted_dog |dog| { assert dog.age == 4 } else { panic "Expected adopted dog" }
+    try adopted_dog |dog| { assert dog.name == "Milo" } else { panic "Expected adopted dog" }
 }
 
-type HasOpt {
-    a: String?
+type UserProfile {
+    nickname: String?
 }
 
 test "Try expression on member does not move" {
-    let maybe = HasOpt(a: "Something")
-    try maybe.a |s| { assert s == "Something" } else { panic "Expected some string" }
-    try maybe.a |s| { assert s == "Something" } else { panic "Expected some string" }
+    let profile = UserProfile(nickname: "pilot")
+    try profile.nickname |nickname| { assert nickname == "pilot" } else { panic "Expected nickname" }
+    try profile.nickname |nickname| { assert nickname == "pilot" } else { panic "Expected nickname" }
 }
 
 test "Try expression on borrowed member does not move" {
-    let maybe = HasOpt(a: "Something")
-    try_on_borrow(maybe)
+    let profile = UserProfile(nickname: "pilot")
+    validate_nickname(profile)
 }
 
-fn try_on_borrow(maybe: HasOpt) {
-    try maybe.a |s| { assert s == "Something" } else { panic "Expected some string" }
+fn validate_nickname(profile: UserProfile) {
+    try profile.nickname |nickname| { assert nickname == "pilot" } else { panic "Expected nickname" }
 }
 
-fn returns_result(ok: Bool) -> Int!Int {
-    if ok {
+fn load_reward_points(available: Bool) -> Int!Int {
+    if available {
         42
     } else {
         throw 21
@@ -110,57 +110,57 @@ fn returns_result(ok: Bool) -> Int!Int {
 }
 
 test "Try expression on result" {
-    let result = returns_result(true)
-    try result |ok| {
-        assert ok == 42
+    let points = load_reward_points(true)
+    try points |loaded| {
+        assert loaded == 42
     } else {
-        panic "Result value was expected to be okay but was error"
+        panic "Expected reward points"
     }
 
-    let result = returns_result(false)
-    try result |ok| {
-        panic "Result value was expected to be error but was ok"
-    } else |err| {
-        assert err == 21
+    let points = load_reward_points(false)
+    try points |loaded| {
+        panic "Expected reward loading to fail"
+    } else |error_code| {
+        assert error_code == 21
     }
 }
 
-fn double_or_minus_one(maybe: Int?) -> Int {
-    let num = maybe else { return -1 }
-    num * 2
+fn double_discount_or_missing(discount: Int?) -> Int {
+    let amount = discount else { return -1 }
+    amount * 2
 }
 
 test "Return from else on optional" {
-    let result = double_or_minus_one(none)
-    assert result == -1
+    let discount = double_discount_or_missing(none)
+    assert discount == -1
 }
 
-fn result_or_fallback(ok: Bool) -> Int {
-    returns_result(ok) else { 99 }
+fn points_or_signup_bonus(available: Bool) -> Int {
+    load_reward_points(available) else { 99 }
 }
 
-fn result_or_error_plus_one(ok: Bool) -> Int {
-    returns_result(ok) else |err| { err + 1 }
+fn points_or_retry_code(available: Bool) -> Int {
+    load_reward_points(available) else |error_code| { error_code + 1 }
 }
 
 test "Else unwrap on result" {
-    assert result_or_fallback(true) == 42
-    assert result_or_fallback(false) == 99
-    assert result_or_error_plus_one(false) == 22
+    assert points_or_signup_bonus(true) == 42
+    assert points_or_signup_bonus(false) == 99
+    assert points_or_retry_code(false) == 22
 }
 
 test "Safe-call -> else on struct member" {
-    let maybe_dog: Dog? = Dog(name: "Hugo", age: 8)
-    let dog_name: String = maybe_dog?.name else { "Bello" }
+    let shelter_dog: Dog? = Dog(name: "Hugo", age: 8)
+    let displayed_name: String = shelter_dog?.name else { "Unknown" }
 
-    assert dog_name == "Hugo"
-    assert maybe_dog?.name == "Hugo" 
+    assert displayed_name == "Hugo"
+    assert shelter_dog?.name == "Hugo" 
 }
 
 test "Try-expression on struct member" {
-    let maybe_dog: Dog? = Dog(name: "Hugo", age: 8)
-    let dog_name: String = try maybe_dog |dog| { dog.name } else { "Bello" }
+    let shelter_dog: Dog? = Dog(name: "Hugo", age: 8)
+    let displayed_name: String = try shelter_dog |dog| { dog.name } else { "Unknown" }
 
-    assert dog_name == "Hugo"
-    assert maybe_dog?.name == "Hugo" 
+    assert displayed_name == "Hugo"
+    assert shelter_dog?.name == "Hugo" 
 }

--- a/galvan-test/src/for.galvan
+++ b/galvan-test/src/for.galvan
@@ -1,56 +1,56 @@
 test "for loop works" {
-    let numbers = [1, 2, 3, 4, 5]
-    mut i = 1
-    mut last = 0
+    let daily_orders = [1, 2, 3, 4, 5]
+    mut expected_orders = 1
+    mut last_day_orders = 0
 
-    for numbers |elem| {
-        assert elem == i
-        i += 1
-        last = elem
+    for daily_orders |orders| {
+        assert orders == expected_orders
+        expected_orders += 1
+        last_day_orders = orders
     }
 
-    assert last == 5
+    assert last_day_orders == 5
 }
 
 test "zipping iterators" {
-    let num1 = [6, 5, 4, 3, 2, 1, 0]
-    let num2 = [0, 1, 2, 3, 4, 5, 6]
+    let morning_slots = [6, 5, 4, 3, 2, 1, 0]
+    let evening_slots = [0, 1, 2, 3, 4, 5, 6]
 
-    for num1.iter().zip(num2) |a, b| {
-        assert a + b == 6
+    for morning_slots.iter().zip(evening_slots) |morning, evening| {
+        assert morning + evening == 6
     }
 }
 
 test "for expression" {
-    let numbers = [1, 4, 5, 7, 10]
-    let doubled = for numbers |num| {
-        num * 2
+    let prices = [1, 4, 5, 7, 10]
+    let doubled_prices = for prices |price| {
+        price * 2
     }
 
-    assert doubled.len() == 5
+    assert doubled_prices.len() == 5
 
-    assert doubled[2] == 10
-    assert doubled[4] == 20
+    assert doubled_prices[2] == 10
+    assert doubled_prices[4] == 20
 
-    for numbers.iter().zip(doubled) |a, b| {
-        assert a * 2 == b * 1
+    for prices.iter().zip(doubled_prices) |price, doubled| {
+        assert price * 2 == doubled * 1
     }
 }
 
 fn doubled(self: [Int]) -> [Int]? {
-    for self |elem| {
-        elem * 2
+    for self |amount| {
+        amount * 2
     }
 }
 
 test "autowrap for when optional is expected" {
-    let numbers = [1, 2, 3, 4, 5]
+    let invoice_amounts = [1, 2, 3, 4, 5]
 
-    let doubled = numbers.doubled()
+    let doubled_amounts = invoice_amounts.doubled()
 }
 
 test "ownership for iterators" {
-    let dogs = [Dog(name: "Bello", age: 4), Dog(name: "Hasso", age: 7)]
+    let dogs = [Dog(name: "Milo", age: 4), Dog(name: "Scout", age: 7)]
 
     for dogs.iter() |dog| {
         pet(dog)
@@ -60,60 +60,60 @@ test "ownership for iterators" {
 fn pet(dog: Dog) {}
 
 test "break works" {
-    let numbers = [1, 2, 3, 4]
+    let queue_positions = [1, 2, 3, 4]
 
-    for numbers |num| {
-        if num == 3 { break }
-        assert num < 3
+    for queue_positions |position| {
+        if position == 3 { break }
+        assert position < 3
     }
 }
 
 test "continue works" {
-    let numbers = [1, 2, 3, 4]
+    let queue_positions = [1, 2, 3, 4]
 
-    for numbers |num| {
-        if num % 2 == 1 { continue }
-        assert num % 2 == 0
+    for queue_positions |position| {
+        if position % 2 == 1 { continue }
+        assert position % 2 == 0
     }
 }
 
 test "implicit it parameter works" {
-    let numbers = [1, 2, 3]
-    mut sum = 0
-    
-    for numbers {
-        sum += it
+    let invoice_amounts = [1, 2, 3]
+    mut total = 0
+
+    for invoice_amounts {
+        total += it
     }
-    
-    assert sum == 6
+
+    assert total == 6
 }
 
 test "for loop on optional and result" {
-    let maybe: Int? = 3
-    let nothing: Int? = none
-    let ok: Int!Int = 5
-    let err: Int!Int = throw_in_for_test()
-    mut sum = 0
+    let coupon_value: Int? = 3
+    let missing_coupon: Int? = none
+    let loyalty_bonus: Int!Int = 5
+    let failed_bonus: Int!Int = load_missing_bonus()
+    mut total_discount = 0
 
-    for maybe {
-        sum += it
+    for coupon_value {
+        total_discount += it
     }
 
-    for nothing {
-        sum += 100
+    for missing_coupon {
+        total_discount += 100
     }
 
-    for ok {
-        sum += it
+    for loyalty_bonus {
+        total_discount += it
     }
 
-    for err {
-        sum += 100
+    for failed_bonus {
+        total_discount += 100
     }
 
-    assert sum == 8
+    assert total_discount == 8
 }
 
-fn throw_in_for_test() -> Int!Int {
+fn load_missing_bonus() -> Int!Int {
     throw 4
 }

--- a/galvan-test/src/generic.galvan
+++ b/galvan-test/src/generic.galvan
@@ -7,24 +7,24 @@ fn get_value(self: Container<t>) -> t {
 }
 
 test "Simple generic container type" {
-    let container = Container(value: 42)
+    let shipment = Container(value: 42)
 
-    assert container.value == 42
-    assert container.get_value() == 42
+    assert shipment.value == 42
+    assert shipment.get_value() == 42
 }
 
-fn str(a: t) -> String where t: ToString {
-    a.to_string()
+fn str(value: t) -> String where t: ToString {
+    value.to_string()
 }
 
 test "Generic function with 'where' clause" {
-    let in = 15
-    let a = str(in)
-    assert a == "15"
+    let quantity = 15
+    let quantity_text = str(quantity)
+    assert quantity_text == "15"
 
-    let in = "string"
-    let b = str(in)
-    assert b == "string"
+    let label = "fragile"
+    let label_text = str(label)
+    assert label_text == "fragile"
 }
 
 fn repr(self: t) -> String where t: ToString {
@@ -32,11 +32,11 @@ fn repr(self: t) -> String where t: ToString {
 }
 
 test "Generic method with 'where' clause" {
-    let a = 15.repr()
-    assert a == "15"
+    let quantity_text = 15.repr()
+    assert quantity_text == "15"
 
-    let b = "string".repr()
-    assert b == "string"
+    let label_text = "fragile".repr()
+    assert label_text == "fragile"
 }
 
 fn concat_str(self: a, other: b) -> String where a, b: ToString {
@@ -44,8 +44,8 @@ fn concat_str(self: a, other: b) -> String where a, b: ToString {
 }
 
 test "Generic function with param list in 'where' clause" {
-    let concat = "some ".concat_str("string")
-    assert concat == "some string"
+    let tracking_label = "order ".concat_str("ready")
+    assert tracking_label == "order ready"
 }
 
 // test "Generic function with integer literal as argument" {

--- a/galvan-test/src/generic.galvan
+++ b/galvan-test/src/generic.galvan
@@ -48,7 +48,7 @@ test "Generic function with param list in 'where' clause" {
     assert tracking_label == "order ready"
 }
 
-// test "Generic function with integer literal as argument" {
-//     let concat = 15.concat_str(12)
-//     assert concat == "1512"
-// }
+test "Generic function with integer literal as argument" {
+    let concat = 15.concat_str(12)
+    assert concat == "1512"
+}

--- a/galvan-test/src/map.galvan
+++ b/galvan-test/src/map.galvan
@@ -1,150 +1,150 @@
 test "Access map" {
-    let map = {
+    let pantry = {
         "oranges": 4,
         "apples": 5,
-        "brussel sprouts": 14,
+        "coffee": 14,
     }
 
-    assert map["oranges"] == 4
-    assert map["apples"] == 5
-    assert map["brussel sprouts"] == 14
+    assert pantry["oranges"] == 4
+    assert pantry["apples"] == 5
+    assert pantry["coffee"] == 14
 }
 
 test "Insert into map" {
-    mut map = {
+    mut pantry = {
         "oranges": 4,
         "apples": 5,
-        "brussel sprouts": 14,
+        "coffee": 14,
     }
 
-    map["kiwis"] = 21
+    pantry["kiwis"] = 21
 
-    assert map["oranges"] == 4
-    assert map["apples"] == 5
-    assert map["brussel sprouts"] == 14
-    assert map["kiwis"] == 21
+    assert pantry["oranges"] == 4
+    assert pantry["apples"] == 5
+    assert pantry["coffee"] == 14
+    assert pantry["kiwis"] == 21
 }
 
 test "Modify map element" {
-    mut map = {
+    mut pantry = {
         "oranges": 4,
         "apples": 5,
-        "brussel sprouts": 14,
+        "coffee": 14,
     }
 
-    map["oranges"] = 16
+    pantry["oranges"] = 16
 
-    assert map["oranges"] == 16
-    assert map["apples"] == 5
-    assert map["brussel sprouts"] == 14
+    assert pantry["oranges"] == 16
+    assert pantry["apples"] == 5
+    assert pantry["coffee"] == 14
 }
 
 test "Access and modify map through ref variable" {
-    ref map = {
+    ref pantry = {
         "oranges": 4,
         "apples": 5,
     }
 
-    assert map["oranges"] == 4
-    map["oranges"] = 16
-    map["kiwis"] = 21
-    assert map["oranges"] == 16
-    assert map["kiwis"] == 21
+    assert pantry["oranges"] == 4
+    pantry["oranges"] = 16
+    pantry["kiwis"] = 21
+    assert pantry["oranges"] == 16
+    assert pantry["kiwis"] == 21
 }
 
 test "Map with type annotation" {
-    let map: {String: Int} = {
+    let pantry: {String: Int} = {
         "oranges": 4,
         "apples": 5,
-        "brussel sprouts": 14,
+        "coffee": 14,
     }
 
-    assert map["oranges"] == 4
-    assert map["apples"] == 5
-    assert map["brussel sprouts"] == 14
+    assert pantry["oranges"] == 4
+    assert pantry["apples"] == 5
+    assert pantry["coffee"] == 14
 }
 
 test "For loop on map" {
-    let map: {String: Int} = {
+    let pantry: {String: Int} = {
         "oranges": 4,
         "apples": 5,
-        "brussel sprouts": 14,
+        "coffee": 14,
     }
-    mut total = 0
+    mut total_items = 0
 
-    for map |fruit, count| {
-        assert fruit.len() > 0
-        total += count
+    for pantry |item, count| {
+        assert item.len() > 0
+        total_items += count
     }
 
-    assert total == 23
+    assert total_items == 23
 }
 
 test "Access ordered map" {
-    let map = [
-        "oranges": 4,
-        "apples": 5,
-        "brussel sprouts": 14,
+    let daily_menu = [
+        "breakfast": 4,
+        "lunch": 5,
+        "dinner": 14,
     ]
 
-    assert map["oranges"] == 4
-    assert map["apples"] == 5
-    assert map["brussel sprouts"] == 14
+    assert daily_menu["breakfast"] == 4
+    assert daily_menu["lunch"] == 5
+    assert daily_menu["dinner"] == 14
 }
 
 test "For loop on ordered map" {
-    let map: [String: Int] = [
-        "oranges": 4,
-        "apples": 5,
-        "brussel sprouts": 14,
+    let daily_menu: [String: Int] = [
+        "breakfast": 4,
+        "lunch": 5,
+        "dinner": 14,
     ]
-    mut total = 0
+    mut total_servings = 0
 
-    for map |fruit, count| {
-        assert fruit.len() > 0
-        total += count
+    for daily_menu |meal, servings| {
+        assert meal.len() > 0
+        total_servings += servings
     }
 
-    assert total == 23
+    assert total_servings == 23
 }
 
 test "Insert into ordered map" {
-    mut map = [
-        "oranges": 4,
-        "apples": 5,
-        "brussel sprouts": 14,
+    mut daily_menu = [
+        "breakfast": 4,
+        "lunch": 5,
+        "dinner": 14,
     ]
 
-    map["kiwis"] = 21
+    daily_menu["dessert"] = 21
 
-    assert map["oranges"] == 4
-    assert map["apples"] == 5
-    assert map["brussel sprouts"] == 14
-    assert map["kiwis"] == 21
+    assert daily_menu["breakfast"] == 4
+    assert daily_menu["lunch"] == 5
+    assert daily_menu["dinner"] == 14
+    assert daily_menu["dessert"] == 21
 }
 
 test "Modify ordered map element" {
-    mut map = [
-        "oranges": 4,
-        "apples": 5,
-        "brussel sprouts": 14,
+    mut daily_menu = [
+        "breakfast": 4,
+        "lunch": 5,
+        "dinner": 14,
     ]
 
-    map["oranges"] = 16
+    daily_menu["breakfast"] = 16
 
-    assert map["oranges"] == 16
-    assert map["apples"] == 5
-    assert map["brussel sprouts"] == 14
+    assert daily_menu["breakfast"] == 16
+    assert daily_menu["lunch"] == 5
+    assert daily_menu["dinner"] == 14
 }
 
 test "Ordered map with type annotation" {
-    let map: [String: Int] = [
-        "oranges": 4,
-        "apples": 5,
-        "brussel sprouts": 14,
+    let daily_menu: [String: Int] = [
+        "breakfast": 4,
+        "lunch": 5,
+        "dinner": 14,
     ]
 
-    assert map["oranges"] == 4
-    assert map["apples"] == 5
-    assert map["brussel sprouts"] == 14
+    assert daily_menu["breakfast"] == 4
+    assert daily_menu["lunch"] == 5
+    assert daily_menu["dinner"] == 14
 }

--- a/galvan-test/src/postfix.galvan
+++ b/galvan-test/src/postfix.galvan
@@ -1,15 +1,15 @@
 test "Use '!' operator on optional" {
-    let bailed = func_with_result()
-    assert bailed.unwrap_err() == 1
+    let missing_guest = find_guest_position()
+    assert missing_guest.unwrap_err() == 1
 }
 
-fn func_with_result() -> Int!USize {
-    let vec = ["H", "Z"]
-    vec.binary_search("Hi")!
-    let bail = vec.binary_search("Hi")!
+fn find_guest_position() -> Int!USize {
+    let guest_names = ["H", "Z"]
+    guest_names.binary_search("Hi")!
+    let position = guest_names.binary_search("Hi")!
 
-    let a = if true { 27 }
-    a.ok_or(27)
+    let fallback_position = if true { 27 }
+    fallback_position.ok_or(27)
 }
 
 fn double(self: Int) -> Int {
@@ -17,15 +17,15 @@ fn double(self: Int) -> Int {
 }
 
 test "Use safe-call operator '?.'" {
-    mut maybe: Int? = none
-    try maybe?.double() |i| {
+    mut maybe_score: Int? = none
+    try maybe_score?.double() |score| {
         panic "Expected optional to be none"
     }
 
-    maybe = 5
+    maybe_score = 5
 
-    try maybe?.double() |i| {
-        assert i == 10
+    try maybe_score?.double() |score| {
+        assert score == 10
     } else {
         panic "Expected optional to have a value"
     }

--- a/galvan-test/src/set.galvan
+++ b/galvan-test/src/set.galvan
@@ -1,76 +1,75 @@
 test "Access set" {
-    let set = {
+    let pantry = {
         "oranges",
         "apples",
-        "brussel sprouts",
+        "coffee",
     }
 
-    assert "oranges" in set
-    assert "apples" in set
-    assert "brussel sprouts" in set
+    assert "oranges" in pantry
+    assert "apples" in pantry
+    assert "coffee" in pantry
 }
 
 test "Insert into set" {
-    mut set = {
+    mut pantry = {
         "oranges",
         "apples",
-        "brussel sprouts",
+        "coffee",
     }
 
-    set ++= "kiwis"
+    pantry ++= "kiwis"
 
-    assert "oranges" in set
-    assert "apples" in set
-    assert "brussel sprouts" in set
+    assert "oranges" in pantry
+    assert "apples" in pantry
+    assert "coffee" in pantry
 }
 
 test "Set with type annotation" {
-    let set: {String} = {
+    let pantry: {String} = {
         "oranges",
         "apples",
-        "brussel sprouts",
+        "coffee",
     }
 
-    assert "oranges" in set
-    assert "apples" in set
-    assert "brussel sprouts" in set
+    assert "oranges" in pantry
+    assert "apples" in pantry
+    assert "coffee" in pantry
 }
 
 test "Merge sets" {
-    let set: {String} = {
+    let stocked_items: {String} = {
         "apples",
         "pineapples"
     }
 
-    let other: {String} = {
+    let requested_items: {String} = {
         "bananas",
         "pears",
     }
 
-    let merged = set ++ other
+    let shopping_list = stocked_items ++ requested_items
 
-    assert "apples" in merged
-    assert "pineapples" in merged
-    assert "bananas" in merged
-    assert "pears" in merged
+    assert "apples" in shopping_list
+    assert "pineapples" in shopping_list
+    assert "bananas" in shopping_list
+    assert "pears" in shopping_list
 }
 
 test "Append sets" {
-    mut set: {String} = {
+    mut stocked_items: {String} = {
         "apples",
         "pineapples"
     }
 
-    let other: {String} = {
+    let requested_items: {String} = {
         "bananas",
         "pears",
     }
 
-    set ++= other
+    stocked_items ++= requested_items
 
-    assert "apples" in set
-    assert "pineapples" in set
-    assert "bananas" in set
-    assert "pears" in set
+    assert "apples" in stocked_items
+    assert "pineapples" in stocked_items
+    assert "bananas" in stocked_items
+    assert "pears" in stocked_items
 }
-

--- a/galvan-test/src/struct.galvan
+++ b/galvan-test/src/struct.galvan
@@ -74,18 +74,18 @@ test "Construct from borrowed parameters" {
 }
 
 type Book {
-    title: String = "Lorem Ipsum"
-    content: String = "Lorem ipsum dolor sit amet..."
+    title: String = "Field Notes"
+    content: String = "No notes yet"
 }
 
 test "Structs with default fields" {
     let book = Book()
-    assert book.title == "Lorem Ipsum"
-    assert book.content == "Lorem ipsum dolor sit amet..."
+    assert book.title == "Field Notes"
+    assert book.content == "No notes yet"
 }
 
 test "Structs with some default fields" {
-    let book = Book(content: "empty")
-    assert book.title == "Lorem Ipsum"
-    assert book.content == "empty"
+    let book = Book(content: "Packed lunch at noon")
+    assert book.title == "Field Notes"
+    assert book.content == "Packed lunch at noon"
 }

--- a/galvan-test/src/trailing_closure.galvan
+++ b/galvan-test/src/trailing_closure.galvan
@@ -48,7 +48,13 @@ fn floor_map(self: [Float], f: |Float| Float) -> [Float] {
     }
 }
 
-// TODO: This currently does not work because the extension function impl block is missing a <T>
+test "Generic trailing-closure helper as member function" {
+    let order_quantities = [1, 2, 3]
+    let doubled_quantities: [Int] = order_quantities.my_map |quantity| { quantity * 2 }
+
+    assert doubled_quantities == [2, 4, 6]
+}
+
 fn my_map(self: [t], f: |t| u) -> [u] {
     for self { f(it) }
 }

--- a/galvan-test/src/trailing_closure.galvan
+++ b/galvan-test/src/trailing_closure.galvan
@@ -1,45 +1,45 @@
 test "Collect iter into vector with trailing closure syntax" {
-    let v = [1, 2, 3, 4, 5, 6, 7, 8]
-    let v = v
+    let order_quantities = [1, 2, 3, 4, 5, 6, 7, 8]
+    let packed_quantities = order_quantities
         .iter()
         .copied()
-        .map |x| { x * 2 }
-        .filter |x| { x % 4 == 0 }
+        .map |quantity| { quantity * 2 }
+        .filter |quantity| { quantity % 4 == 0 }
         .vec()
 
-    assert v == [4, 8, 12, 16]
+    assert packed_quantities == [4, 8, 12, 16]
 }
 
 test "Trailing closure as member function" {
-    let collection = [1, 2, 3, 4, 5, 6, 7, 8]
-    let iter = collection
+    let order_quantities = [1, 2, 3, 4, 5, 6, 7, 8]
+    let doubled_quantities = order_quantities
         .iter()
         .copied()
-        .map |x| { x * 2 }
+        .map |quantity| { quantity * 2 }
 
-    let v = iter
-        .filter |x| { x % 4 == 0 }
+    let packed_quantities = doubled_quantities
+        .filter |quantity| { quantity % 4 == 0 }
         .vec()
 
-    assert v == [4, 8, 12, 16]
+    assert packed_quantities == [4, 8, 12, 16]
 }
 
 test "Paren-less function call as member function" {
-    let collection = [1, 2, 3, 4]
-    let result = collection
-    	.iter()
-	.copied()
-	.map |x| { x * 2 }
-	.fold 2 |acc, e| { acc + e }
+    let order_quantities = [1, 2, 3, 4]
+    let total = order_quantities
+        .iter()
+        .copied()
+        .map |quantity| { quantity * 2 }
+        .fold 2 |acc, quantity| { acc + quantity }
 
-    assert result == 22
+    assert total == 22
 }
 
 test "Call function with specific closure" {
-    let floats = [2.1, 4.5, 6.7]
-    let mapped = floats.floor_map |i| { i * 2.0 }
+    let measurements = [2.1, 4.5, 6.7]
+    let doubled_floors = measurements.floor_map |measurement| { measurement * 2.0 }
 
-    assert mapped == [4.0, 8.0, 12.0]
+    assert doubled_floors == [4.0, 8.0, 12.0]
 } 
 
 fn floor_map(self: [Float], f: |Float| Float) -> [Float] {

--- a/galvan-transpiler/src/codegen/expression.rs
+++ b/galvan-transpiler/src/codegen/expression.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 
 use galvan_ast::{
-    ArithmeticOperator, BitwiseOperator, ComparisonOperator, LogicalOperator, RangeOperator,
+    ArithmeticOperator, BitwiseOperator, ComparisonOperator, Ident, LogicalOperator, RangeOperator,
     TypeElement,
 };
 use galvan_hir::hir::*;
@@ -85,11 +85,7 @@ impl Transpile for HirElseUnwrap {
                 format!("if let Some({value_pattern}) = {receiver} {{ {value} }} else {else_block}")
             }
             HirElseUnwrapKind::Result => {
-                let err_binding = self
-                    .err_binding
-                    .as_ref()
-                    .map(|binding| sanitize_name(binding.as_str()).into_owned())
-                    .unwrap_or_else(|| "_".into());
+                let err_binding = fallback_binding(&self.err_binding);
                 format!(
                     "match {receiver} {{ Ok({value_pattern}) => {{ {value} }}, Err({err_binding}) => {else_block} }}"
                 )
@@ -118,11 +114,7 @@ impl Transpile for HirTry {
                         )
                     }
                     TryKind::Result => {
-                        let err_binding = self
-                            .err_binding
-                            .as_ref()
-                            .map(|binding| sanitize_name(binding.as_str()).into_owned())
-                            .unwrap_or_else(|| "_".into());
+                        let err_binding = fallback_binding(&self.err_binding);
                         format!(
                             "match {condition} {{ Ok({bindings}) => {body}, Err({err_binding}) => {else_block} }}"
                         )
@@ -133,6 +125,13 @@ impl Transpile for HirTry {
             None => format!("r#try({condition}, |{bindings}| {body})"),
         }
     }
+}
+
+fn fallback_binding(binding: &Option<Ident>) -> String {
+    binding
+        .as_ref()
+        .map(|binding| sanitize_name(binding.as_str()).into_owned())
+        .unwrap_or_else(|| "_".into())
 }
 
 impl Transpile for HirFor {

--- a/todo.md
+++ b/todo.md
@@ -63,6 +63,12 @@ commands remain subcommands.
 - **Identifier improvements** (galvan-transpiler/src/transpile_item/ident.rs)
   - Implement fully qualified name lookup / module paths
 
+- **Warning cleanup**
+  - Silence or handle unused-parameter warnings in the tree-sitter external
+    scanner stub (tree-sitter-galvan/src/scanner.c)
+  - Investigate the generic-container type mismatch warning emitted while
+    building `galvan-test`
+
 - **Closure types** (galvan-transpiler/src/transpile_item/type.rs)
   - Let users declare `Fn` instead of `FnMut` closures, e.g. for
     multithreading


### PR DESCRIPTION
## Summary

- cleaned up control-flow lowering and codegen helpers to reduce duplicated binding and ownership logic
- removed a few existing Rust warnings in resolver/AST code
- rewrote Galvan test fixtures to use more relatable names and data without changing what they cover
- reorganized the README, updated implementation status warnings, and documented behavior covered by tests/examples
- recorded remaining warning follow-ups in `todo.md`

## Validation

- `cargo fmt --all`
- `cargo check --workspace`
- `cargo test --workspace`

Known existing warnings remain for the tree-sitter scanner unused parameters and the generic-container diagnostic emitted while building `galvan-test`.
